### PR TITLE
Allow sp to service requests from the backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ services:
     ports:
      - "80:80"
      - "443:443"
+    volumes:
+     - certs:/etc/httpd/ssl
 
   idp:
     build:
@@ -124,10 +126,16 @@ services:
 
   sp:
     build: ./sp/2.6.1
-    image: oapass/sp:20190813@sha256:d75554dd82191ec3201494a2c0db5ba632d0e37141bba6561b5d48fdee916f38
+    image: oapass/sp:20191029
     container_name: sp
+    depends_on:
+     - proxy
     networks:
-     - back
+     back:
+      aliases:
+        - pass.local
+    volumes:
+     - certs:/etc/httpd/ssl
     secrets:
      - source: sp_key
 
@@ -293,6 +301,8 @@ volumes:
   mailstate:
     driver: local
   maildata:
+    driver: local
+  certs:
     driver: local
 
 networks:

--- a/sp/2.6.1/etc-httpd/conf.d/sp.conf
+++ b/sp/2.6.1/etc-httpd/conf.d/sp.conf
@@ -2,6 +2,64 @@ ServerName pass
 LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
 AllowEncodedSlashes NoDecode
 
+<VirtualHost *:443>
+    DocumentRoot "/var/www/html"
+    AllowEncodedSlashes NoDecode
+    UseCanonicalName On
+
+    SSLEngine on
+
+    #Disable CRIME vulernability v2.4+
+    SSLCompression off
+
+    #Clean SSL Issues and enable perfect forward secrecy
+    SSLProtocol all -SSLv2 -SSLv3 -TLSv1
+    SSLHonorCipherOrder on
+    SSLCipherSuite "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 \
+EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 \
+EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
+
+    #SSL Cert Stuff
+    SSLCertificateFile    /etc/httpd/ssl/domain.crt
+    SSLCertificateKeyFile /etc/httpd/ssl/domain.key
+    #SSLCertificateChainFile /etc/httpd/ssl/serverchain.pem
+
+    SSLProxyEngine on
+    #Bypassing certicate checking on self-signed client cert
+    SSLProxyVerify none
+    SSLProxyCheckPeerCN off
+    SSLProxyCheckPeerName off
+    SSLProxyCheckPeerExpire off
+
+    ProxyPreserveHost on
+    RequestHeader set X-Forwarded-Proto "https" env=HTTPS
+    #RequestHeader set REMOTE-USER %{REMOTE_USER}s
+
+    ProxyIOBufferSize 65536
+    ProxyPassReverse /fcrepo http://fcrepo:8080/fcrepo
+    ProxyPass /fcrepo http://fcrepo:8080/fcrepo
+
+    ProxyPassReverse /pass-user-service http://fcrepo:8080/pass-user-service
+    ProxyPass /pass-user-service http://fcrepo:8080/pass-user-service
+
+    ProxyPassReverse /app http://ember:81/app
+    ProxyPass /app http://ember:81/app
+
+    ProxyPass /es http://elasticsearch:9200/pass/_search
+    ProxyPassReverse /es http://elasticsearch:9200/pass/_search
+
+    ProxyPassReverse /schemaservice http://schemaservice:8086
+    ProxyPass /schemaservice http://schemaservice:8086
+
+    ProxyPassReverse /policyservice http://policyservice:8088
+    ProxyPass /policyservice http://policyservice:8088
+
+    ProxyPassReverse /doiservice http://doiservice:8080/pass-doi-service
+    ProxyPass /doiservice http://doiservice:8080/pass-doi-service
+
+
+</VirtualHost>
+
 <VirtualHost *:80>
 
     ServerName https://pass.local:443


### PR DESCRIPTION
Note: This is an experimental demonstration PR for the data archive https://github.com/jhu-sheridan-libraries/jhuda-general-issues/issues/23

Backend services can now use "frontend" URIs for accessing Fedora, and
other public services.  e.g. https://pass.local/fcrepo/rest/foo will
route to `sp`, and can be reverse-proxied to its final destination from
there (bypassing SHibboleth)

Note:  This doesn't change any of the backend service to _use_ the public URIs, it just demonstrates the required network plumbing to make public URIs like `https://pass.local/fcrepo/rest/files` accessible from within containers.

# To test
* build the `sp` image `docker-compose build sp`
* do a `docker-compose up -d`
* hop into a container and use `curl` using a public URI

