### PR TITLE
Release of Notification Services version 0.1.0-3.4.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,7 +249,7 @@ services:
 
   notification:
     build: notification-services/0.1.0-3.4
-    image: oapass/notification-services:0.1.0-3.4-SNAPSHOT@sha256:a7ce9069f92d2a2c8a0ab2558718f8f21097880272af20a4868a31a013d78da5
+    image: oapass/notification-services:0.1.0-3.4@sha256:438372625923f1b71af3f9142dc4f142db040c16d6871b07ab52fc06a3bc8e8f
     container_name: notification
     networks:
       - back

--- a/notification-services/0.1.0-3.4/Dockerfile
+++ b/notification-services/0.1.0-3.4/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u212-jre-alpine3.9@sha256:5c5867cd2d4d198d1e53562c8202dfa388832b6f7d8276e69eae212b326c7777
 
-ENV NOTIFICATION_SERVICES_VERSION=0.1.0-3.4-SNAPSHOT \
-    JSONLD_CONTEXT_VERSION=3.2 \
+ENV NOTIFICATION_SERVICES_VERSION=0.1.0-3.4 \
+    JSONLD_CONTEXT_VERSION=3.4 \
     FCREPO_HOST=${FCREPO_HOST:-fcrepo} \
     FCREPO_PORT=${FCREPO_PORT:-8080} \
     FCREPO_JMS_PORT=${FCREPO_JMS_PORT:-61616} \
@@ -21,7 +21,7 @@ ENV NOTIFICATION_SERVICES_VERSION=0.1.0-3.4-SNAPSHOT \
 RUN apk update && \
     apk add --no-cache wget && \
     wget -O notification-services.jar \
-        https://oss.sonatype.org/content/repositories/snapshots/org/dataconservancy/pass/notify/notification-boot/0.1.0-3.4-SNAPSHOT/notification-boot-0.1.0-3.4-20200611.135820-1-exec.jar && \
+        https://repo1.maven.org/maven2/org/dataconservancy/pass/notify/notification-boot/${NOTIFICATION_SERVICES_VERSION}/notification-boot-${NOTIFICATION_SERVICES_VERSION}-exec.jar && \
     echo "networkaddress.cache.ttl=10" >> ${JAVA_HOME}/lib/security/java.security
     
 


### PR DESCRIPTION
# About
This is a [production release](https://github.com/OA-PASS/notification-services/releases/tag/0.1.0-3.4) of Notification Services that includes BCC support, and adds diagnostic SMTP headers to email messages used for integration tests.  It updates the configuration file for notification services so that BCC addresses may be supported via ENV vars:

`PASS_NOTIFICATION_DEMO_GLOBAL_BCC_ADDRESS`
`PASS_NOTIFICATION_PRODUCTION_GLOBAL_BCC_ADDRESS`

# How to test

1.  Start pass-docker.
1.  Tail the logs of the `notification` container (`docker logs -f notification`)
1.  Prepare a submission on behalf of someone else
    - If you prepare a submission using an email address and name, you _must_ use an email address that ends with '@jhu.edu'.  Any of our test accounts like `facultywithgrants@jhu.edu` or `staffwithgrants@jhu.edu` should work.
1.  See the notification appear in the logs, and note the BCC address

If you want to actually see the content of the notification in the BCC addressee's inbox:
1.  Obtain a shell in the `mail` container (`docker exec -ti mail /bin/bash`)
1.  Navigate to the **BCC** user email directory`/var/spool/mail/jhu.edu/notification-demo-bcc/new`

Every file in the directory will contain an email message.  The file name is based on the SMTP message ID.  If you only prepared a single submission, then there'll be one file containing the BCC notification.  If you prepared two submissions, there'll be two files, and so on.

> The mail server uses a volume to keep old emails.  So if you have performed this test before, or run the docker stack at any time with the BCC-enabled NS, you may have old emails in this file.  Be sure to double check that the timestamp on the mail is what is expected (e.g. a time that corresponds to the time you performed the submission).

Look at the content of the file, note the headers: you are looking at the **BCC** email, but you'll see that the BCC user is not shown in the headers.

Other notable aspects are the presence of X-* headers containing the notification type and the submission resource uri.


