### PR TITLE
Use minimal, anonymous assets image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         METADATA_SCHEMA_URI: "${METADATA_SCHEMA_URI}"
         MANUSCRIPT_SERVICE_LOOKUP_URL: "${MANUSCRIPT_SERVICE_LOOKUP_URL}"
         MANUSCRIPT_SERVICE_DOWNLOAD_URL: "${MANUSCRIPT_SERVICE_DOWNLOAD_URL}"
-    image: oapass/ember:20200820-bfaeb5af@sha256:30078e3face08f324c8b2f1dbf93c02789bc8c3665d1269fc3a7586fb214d238
+    image: oapass/ember:foooo
     container_name: ember
     env_file: .env
     networks:
@@ -119,7 +119,7 @@ services:
       context: ./ldap
       args:
         TENANT: jhu
-    image: oapass/ldap:20200610-jhu@sha256:44d56b80763c8f11d5db082d3bd2ab78614fcb8e7b6544a146b48d098a2672ce
+    image: oapass/ldap:20210809-jhu-anon
     container_name: ldap
     networks:
      - back
@@ -186,7 +186,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2019-04-08_3.4@sha256:7ec44bd52d7cf635ad05a3f509cf7439e187b7768b8a05abae81b49744ec9d5f
+    image:  oapass/assets:2021-08-09_3.4
     build: ./assets
     volumes:
       - passdata:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         METADATA_SCHEMA_URI: "${METADATA_SCHEMA_URI}"
         MANUSCRIPT_SERVICE_LOOKUP_URL: "${MANUSCRIPT_SERVICE_LOOKUP_URL}"
         MANUSCRIPT_SERVICE_DOWNLOAD_URL: "${MANUSCRIPT_SERVICE_DOWNLOAD_URL}"
-    image: oapass/ember:foooo
+    image: oapass/ember:20200820-bfaeb5af@sha256:30078e3face08f324c8b2f1dbf93c02789bc8c3665d1269fc3a7586fb214d238
     container_name: ember
     env_file: .env
     networks:
@@ -119,7 +119,7 @@ services:
       context: ./ldap
       args:
         TENANT: jhu
-    image: oapass/ldap:20210809-jhu-anon
+    image: oapass/ldap:20210809-jhu-anon@sha256:059f4b287a8a1e8381afeca0e3e13b0255ccf2d93d50d8b318fc8d9826f5d5e5
     container_name: ldap
     networks:
      - back
@@ -186,7 +186,7 @@ services:
       - assets
 
   assets:
-    image:  oapass/assets:2021-08-09_3.4
+    image:  oapass/assets:2021-08-09_3.4@sha256:f3936f9708acf0c0dfc8088b651438a48a56474a784aef8f473292cfff8f73a2
     build: ./assets
     volumes:
       - passdata:/data

--- a/ldap/jhu/users.ldif
+++ b/ldap/jhu/users.ldif
@@ -20,8 +20,8 @@ sn: Hasgrants
 cn: Staff Hasgrants
 mail: staffWithGrants@jhu.edu
 userPassword: moo
-eduPersonUniqueId: 3PD4GS
-employeeNumber: 00017179
+eduPersonUniqueId: FAKESWG
+employeeNumber: 906502
 displayName: Staff Hasgrants
 employeeType: STAFF
 homeDirectory: /home/staff1
@@ -62,8 +62,8 @@ sn: Hasgrants
 cn: Faculty Hasgrants
 mail: facultyWithGrants@jhu.edu
 userPassword: moo
-eduPersonUniqueId: UC8KV5
-employeeNumber: 00003343
+eduPersonUniqueId: MF150
+employeeNumber: 150
 displayName: Faculty Hasgrants
 employeeType: FACULTY
 homeDirectory: /home/faculty1
@@ -104,8 +104,8 @@ sn: Ser
 cn: Nihu Ser
 mail: nihuser@jhu.edu
 userPassword: moo
-eduPersonUniqueId: KYWJIT
-employeeNumber: 00001421
+eduPersonUniqueId: NIHUSER
+employeeNumber: 118110
 displayName: Nihu Ser
 employeeType: FACULTY
 homeDirectory: /home/nih-user


### PR DESCRIPTION
Removes most data except for a few example grants and submissions for
users: staff1, staff2, faculty1, faculty2, nih-user

This is a quick and dirty anonymization of the asssets image that
outside collaborators can pull and run.