### PR TITLE
Fix syntax error for static-html reference

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       args:
         STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
         STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: oapass/static-html:jhu-20220405-3683b71@sha256:sha256:004ee85541a607b17f0d20be56b1df9c99c954dc1c5b331b1325cc0b84a250c7
+    image: oapass/static-html:jhu-20220405-3683b71@sha256:004ee85541a607b17f0d20be56b1df9c99c954dc1c5b331b1325cc0b84a250c7
     container_name: static-html
     env_file: .env
     ports:


### PR DESCRIPTION
Invalid tag reference was included by accident with previous commit, which will prevent docker-compose from starting up until the error in the `docker-compose.yml` file is corrected. Won't directly effect deployments (which doesn't use docker-compose) but does effect local development environment