### PR TITLE
Integrate work Aaron Birkland did to remove JHU assets from stack.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       context: ./ldap
       args:
         TENANT: jhu
-    image: oapass/ldap:20210809-jhu-anon@sha256:059f4b287a8a1e8381afeca0e3e13b0255ccf2d93d50d8b318fc8d9826f5d5e5
+    image: oapass/ldap:0.1.0@sha256:059f4b287a8a1e8381afeca0e3e13b0255ccf2d93d50d8b318fc8d9826f5d5e5
     container_name: ldap
     networks:
      - back
@@ -186,7 +186,7 @@ services:
       - assets
 
   assets:
-    image: oapass/assets:2021-08-09_3.4@sha256:f3936f9708acf0c0dfc8088b651438a48a56474a784aef8f473292cfff8f73a2
+    image: oapass/assets:0.1.0@sha256:f3936f9708acf0c0dfc8088b651438a48a56474a784aef8f473292cfff8f73a2
     build: ./assets
     volumes:
       - passdata:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       context: ./ldap
       args:
         TENANT: jhu
-    image: oapass/ldap:0.1.0@sha256:fd66cb1255b81b81ae602d1ccf56d8534e80a6ee27bccc1de014efab58cbf28c
+    image: oapass/ldap:20210809-jhu-anon@sha256:059f4b287a8a1e8381afeca0e3e13b0255ccf2d93d50d8b318fc8d9826f5d5e5
     container_name: ldap
     networks:
      - back
@@ -186,7 +186,7 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2019-04-08_3.4@sha256:7ec44bd52d7cf635ad05a3f509cf7439e187b7768b8a05abae81b49744ec9d5f
+    image: oapass/assets:2021-08-09_3.4@sha256:f3936f9708acf0c0dfc8088b651438a48a56474a784aef8f473292cfff8f73a2
     build: ./assets
     volumes:
       - passdata:/data

--- a/ldap/jhu/users.ldif
+++ b/ldap/jhu/users.ldif
@@ -20,8 +20,8 @@ sn: Hasgrants
 cn: Staff Hasgrants
 mail: staffWithGrants@jhu.edu
 userPassword: moo
-eduPersonUniqueId: 3PD4GS
-employeeNumber: 00017179
+eduPersonUniqueId: FAKESWG
+employeeNumber: 906502
 displayName: Staff Hasgrants
 employeeType: STAFF
 homeDirectory: /home/staff1
@@ -62,8 +62,8 @@ sn: Hasgrants
 cn: Faculty Hasgrants
 mail: facultyWithGrants@jhu.edu
 userPassword: moo
-eduPersonUniqueId: UC8KV5
-employeeNumber: 00003343
+eduPersonUniqueId: MF150
+employeeNumber: 150
 displayName: Faculty Hasgrants
 employeeType: FACULTY
 homeDirectory: /home/faculty1
@@ -104,8 +104,8 @@ sn: Ser
 cn: Nihu Ser
 mail: nihuser@jhu.edu
 userPassword: moo
-eduPersonUniqueId: KYWJIT
-employeeNumber: 00001421
+eduPersonUniqueId: NIHUSER
+employeeNumber: 118110
 displayName: Nihu Ser
 employeeType: FACULTY
 homeDirectory: /home/nih-user


### PR DESCRIPTION
This provides an assets image without any data from JHU. The vast majority of all the objects are Journals.

In addition, the test user ldap info is adjusted slightly. The adjustment to the test users is incompatible with the older assets image which has JHU data. Given this incompatibility, providing an optional override JHU assets docker-compose file will not work without also reverting the ldap change.

In order to test, login with a test user like nih-user and experiment with the workflow.