### PR TITLE
Only expose elasticsearch on the internal IP address (same as publish_host)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,7 @@ services:
     environment:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
+      - network.bind_host=_eth1_
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:


### PR DESCRIPTION
These changes were based on `minimal-assets` (via `178-docker-compose-gh-actions`,
but _should_ work fine on the main branch.

Let's say the application is running on `165.227.33.136`

You should NOT be able to do this

```
telnet 165.227.33.136 9200
```

Here are the special values that I found
https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#network-interface-values

* _local_
*  _site_
*  _global_
*  _[networkInterface]_ (e.g. _eth1_)
*  0.0.0.0

When you load the service by default we see

```
publish_address {172.18.0.8:9300}, bound_addresses {0.0.0.0:9300}
publish_address {172.18.0.8:9200}, bound_addresses {0.0.0.0:9200}
```

Where `0.0.0.0` is from anywhere and `172...` is within the network
(more secure) and then finally `127.0.0.1` (or `localhost`) would
be on that particular machine.

The fields that can be edited are

```
elasticsearch:
  ...
  environment:
      - network.host=_local_
      - network.bind_host=_local_
      - network.publish_host=_local_
```

So in the case above, I think we want to be able to connect via

```
telnet 172.18.0.7 9200

telnet 127.0.0.1 9200

telnet 165.227.33.136 92100
```

When you run `network.bind_host=_local_` you will see

```
publish_address {172.18.0.9:9300}, bound_addresses {127.0.0.1:9300}
publish_address {172.18.0.9:9200}, bound_addresses {127.0.0.1:9200}
```

But get zero connectivity.  The same was found to be true for
`_site_` you will see

```
publish_address {172.18.0.9:9300}, bound_addresses {172.18.0.9:9300}, {172.20.0.19:9300}
publish_address {172.18.0.9:9200}, bound_addresses {172.18.0.9:9200}, {172.20.0.19:9200}
```

BUT, we still have access via the external IP, so going to
explicitly call out `_eth1_` to limit it to the publish address.

```
publish_address {172.18.0.9:9300}, bound_addresses {172.18.0.9:9300}
publish_address {172.18.0.9:9200}, bound_addresses {172.18.0.9:9200}
```

In this case we can access via `172.18.0.9` but not `127.0.0.1` (not great)
but also not `165.227.33.136` which is great.

So leaving it there!!!

(I will need help understanding if it _actually_ still works beyond telnet)