### PR TITLE
Fix "docker-compose down" to use the appropriate files to avoid tear-down errors

### DIFF
--- a/.github/workflows/deploy_passdemo.yml
+++ b/.github/workflows/deploy_passdemo.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Stop Existing App
         run: |
-          docker-compose down
+          docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml down
 
       - name: Build App
         run: |

--- a/.github/workflows/deploy_passnightly.yml
+++ b/.github/workflows/deploy_passnightly.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Stop Existing App
         run: |
-          docker-compose down
+          docker-compose -f eclipse-pass.base.yml -f eclipse-pass.nightly.yml down
 
       - name: Build App
         run: |


### PR DESCRIPTION
Ahh, so docker-compose down needs to load the "right" environment

If you run

```
$ docker-compose down && echo "WORKED"
```

Then you will see

```
WARNING: The USER_SERVICE_URL variable is not set. Defaulting to a blank string.
Stopping ember                  ... done
Stopping proxy                  ... done
Stopping pass-docker_postgres_1 ... done
WARNING: Found orphan containers (pass-docker_elide_1, pass-docker_auth_1) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
Removing ember                  ... done
Removing proxy                  ... done
Removing pass-docker_postgres_1 ... done
Removing network pass-docker_front
ERROR: error while removing network: network pass-docker_front id caa98279855e037d6ef32e4af314c6b7f1a66715c2664fcb4adcb092a6945a06 has active endpoints
```

And that error will stop the build

If you run with the appropriate files, then it will work as expected

```
$ docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml down && echo "WORKED"
```

```
Stopping pass-docker_elide_1 ... done
Stopping pass-docker_auth_1  ... done
Removing pass-docker_elide_1 ... done
Removing pass-docker_auth_1  ... done
Removing network pass-docker_back
Removing network pass-docker_front
WORKED
```