### PR TITLE
Update demo env

### DIFF
--- a/.demo_env
+++ b/.demo_env
@@ -12,7 +12,8 @@ JDBC_DATABASE_USERNAME=pass
 JDBC_DATABASE_PASSWORD=moo
 
 ###################################################
-# PASS_UI config #################################
+# PASS_UI config ##################################
+# ## Changes here require new image build #########
 ###################################################
 # Ember app runtime config
 PASS_UI_PORT=81

--- a/.demo_env
+++ b/.demo_env
@@ -1,6 +1,7 @@
 ###################################################
 # PASS_CORE config ####################################
 ###################################################
+PASS_CORE_BASE_URL=https://pass.local
 PASS_CORE_POSTGRES_PORT=5432
 PASS_CORE_API_PORT=8080
 POSTGRES_USER=postgres
@@ -15,7 +16,7 @@ JDBC_DATABASE_PASSWORD=moo
 ###################################################
 # Ember app runtime config
 PASS_UI_PORT=81
-PASS_API_NAMESPACE=api/v1
+PASS_API_NAMESPACE=data
 
 # PASS_UI app build-time config
 PASS_UI_GIT_REPO=https://github.com/eclipse-pass/pass-ui
@@ -25,19 +26,19 @@ PASS_UI_ROOT_URL=/app
 
 STATIC_CONFIG_URL=/app/config.json
 
-# DOI_SERVICE_URL=/doiservice/journal
-# MANUSCRIPT_SERVICE_LOOKUP_URL=/downloadservice/lookup
-# MANUSCRIPT_SERVICE_DOWNLOAD_URL=/downloadservice/download
-# POLICY_SERVICE_POLICY_ENDPOINT=/policyservice/policies
-# POLICY_SERVICE_REPOSITORY_ENDPOINT=/policyservice/repositories
-# SCHEMA_SERVICE_URL=/schemaservice
-# USER_SERVICE_URL=/pass-user-service/whoami
+DOI_SERVICE_URL=/doiservice/journal
+MANUSCRIPT_SERVICE_LOOKUP_URL=/downloadservice/lookup
+MANUSCRIPT_SERVICE_DOWNLOAD_URL=/downloadservice/download
+POLICY_SERVICE_POLICY_ENDPOINT=/policyservice/policies
+POLICY_SERVICE_REPOSITORY_ENDPOINT=/policyservice/repositories
+SCHEMA_SERVICE_URL=/schemaservice
+USER_SERVICE_URL=/pass-user-service/whoami
 
 ###################################################
 # Auth / Proxy config #############################
 ###################################################
 PASS_CORE_API_URL=http://pass-core:8080/
-PASS_CORE_NAMESPACE=api/v1/
+PASS_CORE_NAMESPACE=data/
 
 PASS_UI_URL=http://pass-ui:81/
 
@@ -76,7 +77,7 @@ DOWNLOAD_SERVICE_URL="http://downloadservice:6502"
 ###################################################
 LOADER_API_HOST=http://pass-core
 LOADER_API_PORT=8080
-LOADER_API_NAMESPACE=api/v1
+LOADER_API_NAMESPACE=data
 
 ###################################################
 # Static HTML config ##############################

--- a/demo-proxy/etc-httpd/conf.d/httpd.conf
+++ b/demo-proxy/etc-httpd/conf.d/httpd.conf
@@ -87,8 +87,8 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPassReverse /swagger http://auth:3000/swagger
 
     # Elide
-    ProxyPass /api/v1 http://auth:3000/api/v1
-    ProxyPassReverse /api/v1 http://auth:3000/api/v1
+    ProxyPass /data http://auth:3000/data
+    ProxyPassReverse /data http://auth:3000/data
 
     # Static pages
     ProxyPass / http://pass-ui-public:82/

--- a/demo.sh
+++ b/demo.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose -f demo.yml --env-file=.demo_env $@
+docker-compose -f demo.yml --env-file .demo_env $@

--- a/demo.yml
+++ b/demo.yml
@@ -2,11 +2,11 @@ version: '3.8'
 
 # When running commands with this file, you must specify both this yml file and
 # the correct env file. For example:
-#   `docker-compose -f demo.yml --env-file=.demo_env up`
+#   `docker-compose -f demo.yml --env-file .demo_env up`
 services:
   auth:
     build: ./sp
-    image: ghcr.io/eclipse-pass/auth:0.2.0@sha256:4e2357d2a309dbf362c0fa8a4047ecd3460b7438eb187c0b951d36b3b343d193
+    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:ae2fff919a5b461279808db38a2945e5be1451ae518d4c11d34cbf4da5572dc4
     env_file: .demo_env
     container_name: auth
     networks:
@@ -14,7 +14,7 @@ services:
       - back
 
   pass-core:
-    image: ghcr.io/eclipse-pass/elide:0.2.0@sha256:de7aac5ad37b7b908f27ebad51f877e1f72078f45f1b26762e822c17b80af8af
+    image: ghcr.io/eclipse-pass/pass-core-main:0.2.0-SNAPSHOT@sha256:7a542ac25167b1abf5b5cb1b71d2ac5ea367627356327f729f8e56c0cf1fea21
     env_file: .demo_env
     container_name: pass-core
     networks:
@@ -23,7 +23,21 @@ services:
       - postgres
   
   pass-ui:
-    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:2312f61ad07245bc1f443577946f1daebced8c06b5d3f1b34438dcba95be57e4
+    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:5a12760f3b1eab292a1694b00080628b6116896aa9a9e58bdeda2c7cffccb872
+    build:
+      context: ./ember
+      args:
+        EMBER_GIT_REPO: "${EMBER_GIT_REPO}"
+        EMBER_GIT_BRANCH: "${EMBER_GIT_BRANCH}"
+        DOI_SERVICE_URL: "${DOI_SERVICE_URL}"
+        MANUSCRIPT_SERVICE_LOOKUP_URL: "${MANUSCRIPT_SERVICE_LOOKUP_URL}"
+        MANUSCRIPT_SERVICE_DOWNLOAD_URL: "${MANUSCRIPT_SERVICE_DOWNLOAD_URL}"
+        METADATA_SCHEMA_URI: "${METADATA_SCHEMA_URI}"
+        PASS_UI_PORT: "${PASS_UI_PORT}"
+        PASS_API_NAMESPACE: "${PASS_API_NAMESPACE}"
+        PASS_UI_ROOT_URL: "${PASS_UI_ROOT_URL}"
+        POLICY_SERVICE_URL: "${POLICY_SERVICE_URL}"
+        USER_SERVICE_URL: "${USER_SERVICE_URL}"
     env_file: .demo_env
     container_name: pass-ui
     networks:
@@ -41,7 +55,7 @@ services:
   
   proxy:
     build: ./demo-proxy/
-    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:5b9eac298a1ee52982bbc94f4995121a8d6ec9b5a47ad40d3f40f4812c5d3087
+    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:caeeab82dc9e4f1ca25670bca1d22aaf0488a7fda0226148b0606441a7b042ae
     container_name: proxy
     networks:
       - front
@@ -99,7 +113,7 @@ services:
      - back
 
   loader:
-    image: ghcr.io/eclipse-pass/demo-loader:0.0.2@sha256:82efd5b465241c3e5f50cbcf4ca30e7e3d4d375a4abe05b7e0348542c85d5d0a
+    image: ghcr.io/eclipse-pass/demo-loader:0.2.0@sha256:42cecc2be7c6a9421094f21327943ac1353fce565c0b4dba003852a31d47f1e8
     env_file: .demo_env
     container_name: loader
     networks:

--- a/demo.yml
+++ b/demo.yml
@@ -6,7 +6,7 @@ version: '3.8'
 services:
   auth:
     build: ./sp
-    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:ae2fff919a5b461279808db38a2945e5be1451ae518d4c11d34cbf4da5572dc4
+    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:13b79c0bdbf7f314cf6fecf4377fed32d8848ac269e3af41034b9b3b8dd87c73
     env_file: .demo_env
     container_name: auth
     networks:
@@ -14,7 +14,7 @@ services:
       - back
 
   pass-core:
-    image: ghcr.io/eclipse-pass/pass-core-main:0.2.0-SNAPSHOT@sha256:7a542ac25167b1abf5b5cb1b71d2ac5ea367627356327f729f8e56c0cf1fea21
+    image: ghcr.io/eclipse-pass/pass-core-main:0.2.0-SNAPSHOT
     env_file: .demo_env
     container_name: pass-core
     networks:
@@ -23,7 +23,7 @@ services:
       - postgres
   
   pass-ui:
-    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:5a12760f3b1eab292a1694b00080628b6116896aa9a9e58bdeda2c7cffccb872
+    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:16608e780279640b400a86678a83555203dcff68fea333681d57742fe100dab2
     build:
       context: ./ember
       args:

--- a/demo.yml
+++ b/demo.yml
@@ -14,7 +14,7 @@ services:
       - back
 
   pass-core:
-    image: ghcr.io/eclipse-pass/pass-core-main:0.2.0-SNAPSHOT
+    image: ghcr.io/eclipse-pass/pass-core-main:0.2.0-SNAPSHOT@sha256:eae7505426547db7b12c6962372a38030deab9567bbbf0cf1fe90629c9457b99
     env_file: .demo_env
     container_name: pass-core
     networks:

--- a/ember/nginx-template.conf
+++ b/ember/nginx-template.conf
@@ -1,5 +1,5 @@
 server {
-    listen       ${EMBER_PORT} default_server;
+    listen       ${PASS_UI_PORT} default_server;
     server_name  _;
 
     #charset utf-8;
@@ -20,7 +20,7 @@ server {
     # 
     # Note, the equals sign means that a 200 is returned
     # instead of a 404
-    error_page 404 = ${EMBER_ROOT_URL}/index.html;
+    error_page 404 = ${PASS_UI_ROOT_URL}/index.html;
 
     # redirect server error pages to the static page /50x.html
     #


### PR DESCRIPTION
Resolves https://github.com/eclipse-pass/main/issues/346

Local validation before updating `eclipse-pass.demo` env

Updates
* pass-core
* pass-auth
* pass-ui
* sample data loader
* proxy

## Manual Testing

* Run `./demo.sh up -d && ./demo.sh logs -f` to bring up the local demo env
* Wait until `pass-core` shows a log message saying that it has started up:
  `[main] [Pass, ] INFO  org.eclipse.pass.main.Main.logStarted - Started Main in 8.677 seconds (JVM running for 9.406)` At this point, pass-core has initialized the DB.
* Run `./demo.sh up loader` to (re)run the sample data loader, which should succeed and exit with code 0
* In your browser, navigate to https://pass.local 
* Login and poke around the PASS UI