### PR TITLE
Allow docker-compose down to "fail" as the services might have significantly changes

### DIFF
--- a/.github/workflows/deploy_passdemo.yml
+++ b/.github/workflows/deploy_passdemo.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Stop Existing App
         run: |
-          docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml down
+          (docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml down || true)
 
       - name: Build App
         run: |

--- a/.github/workflows/deploy_passnightly.yml
+++ b/.github/workflows/deploy_passnightly.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Stop Existing App
         run: |
-          docker-compose -f eclipse-pass.base.yml -f eclipse-pass.nightly.yml down
+          (docker-compose -f eclipse-pass.base.yml -f eclipse-pass.nightly.yml down || true)
 
       - name: Build App
         run: |


### PR DESCRIPTION
When testing against branch `294-load-data-after-up`

If you run

```
docker-compose -f eclipse-pass.base.yml -f eclipse-pass.demo.yml down
```

If will fail because the compose changed _soooo much_.

```
ERROR: The Compose file is invalid because:
Service ember has neither an image nor a build context specified. At least one must be provided.
```

So it should be OK for the "down" to fail and not fail the deploy.