### PR TITLE
Doi redux

### DIFF
--- a/.demo_env
+++ b/.demo_env
@@ -72,7 +72,7 @@ USER_SERVICE_URL="http://fcrepo:8080"
 ELASTIC_SEARCH_URL="http://elasticsearch:9200/pass/_search"
 SCHEMA_SERVICE_URL="http://schemaservice:8086"
 POLICY_SERVICE_URL="http://policyservice:8088"
-DOI_SERVICE_URL="http://doiservice:8080/"
+DOI_SERVICE_URL="http://pass-core:8080"
 DOWNLOAD_SERVICE_URL="http://downloadservice:6502"
 
 ###################################################

--- a/.demo_env
+++ b/.demo_env
@@ -27,7 +27,7 @@ PASS_UI_ROOT_URL=/app
 
 STATIC_CONFIG_URL=/config.json
 
-DOI_SERVICE_URL=/journal
+DOI_SERVICE_PUBLIC_URL=/journal
 MANUSCRIPT_SERVICE_LOOKUP_URL=/downloadservice/lookup
 MANUSCRIPT_SERVICE_DOWNLOAD_URL=/downloadservice/download
 POLICY_SERVICE_POLICY_ENDPOINT=/policyservice/policies

--- a/.demo_env
+++ b/.demo_env
@@ -27,7 +27,7 @@ PASS_UI_ROOT_URL=/app
 
 STATIC_CONFIG_URL=/config.json
 
-DOI_SERVICE_URL=/doiservice/journal
+DOI_SERVICE_URL=/journal
 MANUSCRIPT_SERVICE_LOOKUP_URL=/downloadservice/lookup
 MANUSCRIPT_SERVICE_DOWNLOAD_URL=/downloadservice/download
 POLICY_SERVICE_POLICY_ENDPOINT=/policyservice/policies

--- a/.eclipse-pass.demo_env
+++ b/.eclipse-pass.demo_env
@@ -72,7 +72,7 @@ USER_SERVICE_URL="http://fcrepo:8080"
 ELASTIC_SEARCH_URL="http://elasticsearch:9200/pass/_search"
 SCHEMA_SERVICE_URL="http://schemaservice:8086"
 POLICY_SERVICE_URL="http://policyservice:8088"
-DOI_SERVICE_URL="http://doiservice:8080/"
+DOI_SERVICE_URL="http://pass-core:8080"
 DOWNLOAD_SERVICE_URL="http://downloadservice:6502"
 
 ###################################################

--- a/.eclipse-pass.demo_env
+++ b/.eclipse-pass.demo_env
@@ -27,7 +27,7 @@ PASS_UI_ROOT_URL=/app
 
 STATIC_CONFIG_URL=/config.json
 
-DOI_SERVICE_URL=/journal
+DOI_SERVICE_PUBLIC_URL=/journal
 MANUSCRIPT_SERVICE_LOOKUP_URL=/downloadservice/lookup
 MANUSCRIPT_SERVICE_DOWNLOAD_URL=/downloadservice/download
 POLICY_SERVICE_POLICY_ENDPOINT=/policyservice/policies

--- a/.eclipse-pass.demo_env
+++ b/.eclipse-pass.demo_env
@@ -27,7 +27,7 @@ PASS_UI_ROOT_URL=/app
 
 STATIC_CONFIG_URL=/config.json
 
-DOI_SERVICE_URL=/doiservice/journal
+DOI_SERVICE_URL=/journal
 MANUSCRIPT_SERVICE_LOOKUP_URL=/downloadservice/lookup
 MANUSCRIPT_SERVICE_DOWNLOAD_URL=/downloadservice/download
 POLICY_SERVICE_POLICY_ENDPOINT=/policyservice/policies

--- a/.eclipse-pass.nightly_env
+++ b/.eclipse-pass.nightly_env
@@ -72,7 +72,7 @@ USER_SERVICE_URL="http://fcrepo:8080"
 ELASTIC_SEARCH_URL="http://elasticsearch:9200/pass/_search"
 SCHEMA_SERVICE_URL="http://schemaservice:8086"
 POLICY_SERVICE_URL="http://policyservice:8088"
-DOI_SERVICE_URL="http://doiservice:8080/"
+DOI_SERVICE_URL="http://pass-core:8080"
 DOWNLOAD_SERVICE_URL="http://downloadservice:6502"
 
 ###################################################

--- a/.eclipse-pass.nightly_env
+++ b/.eclipse-pass.nightly_env
@@ -27,7 +27,7 @@ PASS_UI_ROOT_URL=/app
 
 STATIC_CONFIG_URL=/config.json
 
-DOI_SERVICE_URL=/journal
+DOI_SERVICE_PUBLIC_URL=/journal
 MANUSCRIPT_SERVICE_LOOKUP_URL=/downloadservice/lookup
 MANUSCRIPT_SERVICE_DOWNLOAD_URL=/downloadservice/download
 POLICY_SERVICE_POLICY_ENDPOINT=/policyservice/policies

--- a/.eclipse-pass.nightly_env
+++ b/.eclipse-pass.nightly_env
@@ -27,7 +27,7 @@ PASS_UI_ROOT_URL=/app
 
 STATIC_CONFIG_URL=/config.json
 
-DOI_SERVICE_URL=/doiservice/journal
+DOI_SERVICE_URL=/journal
 MANUSCRIPT_SERVICE_LOOKUP_URL=/downloadservice/lookup
 MANUSCRIPT_SERVICE_DOWNLOAD_URL=/downloadservice/download
 POLICY_SERVICE_POLICY_ENDPOINT=/policyservice/policies

--- a/demo-proxy/etc-httpd/conf.d/httpd.conf
+++ b/demo-proxy/etc-httpd/conf.d/httpd.conf
@@ -90,6 +90,10 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPass /data http://auth:3000/data
     ProxyPassReverse /data http://auth:3000/data
 
+   # Doi Service
+    ProxyPass /journal http://auth:3000/journal
+    ProxyPassReverse /journal http://auth:3000/journal
+
     # Static pages
     ProxyPass / http://pass-ui-public:82/
     ProxyPassReverse / http://pass-ui-public:82/

--- a/demo-proxy/etc-httpd/conf.d/httpd.conf
+++ b/demo-proxy/etc-httpd/conf.d/httpd.conf
@@ -91,8 +91,8 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPassReverse /data http://auth:3000/data
 
    # Doi Service
-    ProxyPass /journal http://auth:3000/journal
-    ProxyPassReverse /journal http://auth:3000/journal
+    ProxyPass /journal http://auth:3000/doiservice/journal
+    ProxyPassReverse /journal http://auth:3000/doiservice/journal
 
     # Static pages
     ProxyPass / http://pass-ui-public:82/

--- a/demo-proxy/etc-httpd/conf.d/httpd.conf
+++ b/demo-proxy/etc-httpd/conf.d/httpd.conf
@@ -91,8 +91,8 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPassReverse /data http://auth:3000/data
 
    # Doi Service
-    ProxyPass /journal http://auth:3000/doiservice/journal
-    ProxyPassReverse /journal http://auth:3000/doiservice/journal
+    ProxyPass /journal http://auth:3000/journal
+    ProxyPassReverse /journal http://auth:3000/journal
 
     # Static pages
     ProxyPass / http://pass-ui-public:82/

--- a/demo.yml
+++ b/demo.yml
@@ -57,7 +57,7 @@ services:
   
   proxy:
     build: ./demo-proxy/
-    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:caeeab82dc9e4f1ca25670bca1d22aaf0488a7fda0226148b0606441a7b042ae
+    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:d58e6e123a922573c255edb3b20053fdd9aa494fa2f6cd6c46b46985650f472f
     container_name: proxy
     networks:
       - front

--- a/demo.yml
+++ b/demo.yml
@@ -14,7 +14,7 @@ services:
       - back
 
   pass-core:
-    image: ghcr.io/eclipse-pass/pass-core-main:0.2.0-SNAPSHOT@sha256:eae7505426547db7b12c6962372a38030deab9567bbbf0cf1fe90629c9457b99
+    image: ghcr.io/eclipse-pass/pass-core-main:0.2.0-SNAPSHOT@sha256:bd0b8b3a79a5e476bed8545c3738b274922e6421be1bd39c5b1a3518a326fb23
     env_file: .demo_env
     container_name: pass-core
     networks:

--- a/demo.yml
+++ b/demo.yml
@@ -6,7 +6,7 @@ version: '3.8'
 services:
   auth:
     build: ./sp
-    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:08d3afb4ee4a7042c97d6d9a889b4adeeff0dfc199fa24d397a1c71830d3be5e
+    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:b32633e39b820bb7047a72922934503f71028dcf401396b96522c4535427d830
     env_file: .demo_env
     container_name: auth
     networks:
@@ -23,7 +23,7 @@ services:
       - postgres
   
   pass-ui:
-    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:e8a550cca8d906f046995cb3d96f12655c8f6569838364c574a4e604e00a5370
+    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:e78e363a4185ee96c9a83478546c43698f0373d900911d7082c9350ce8aced81
     build:
       context: ./ember
       args:
@@ -57,7 +57,7 @@ services:
   
   proxy:
     build: ./demo-proxy/
-    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:115b4d0407d6772ce7ca267eaed7931148a72d59b147a784d6e58ae1876c4214
+    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:07847ef518d96464007aa583f1edbc505bd3221bc5d3d195609d8e1fbfa7822e
     container_name: proxy
     networks:
       - front

--- a/demo.yml
+++ b/demo.yml
@@ -6,7 +6,7 @@ version: '3.8'
 services:
   auth:
     build: ./sp
-    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:1149308b52a01b83ff490ac01490eaff7440dff8e35828f65093129bda30c6ca
+    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:08d3afb4ee4a7042c97d6d9a889b4adeeff0dfc199fa24d397a1c71830d3be5e
     env_file: .demo_env
     container_name: auth
     networks:

--- a/demo.yml
+++ b/demo.yml
@@ -23,7 +23,7 @@ services:
       - postgres
   
   pass-ui:
-    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:214fac075acc10f37c8aba318463979dba9f47be93a6c4019d2a8a7c57b9f302
+    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:e8a550cca8d906f046995cb3d96f12655c8f6569838364c574a4e604e00a5370
     build:
       context: ./ember
       args:
@@ -57,7 +57,7 @@ services:
   
   proxy:
     build: ./demo-proxy/
-    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:d58e6e123a922573c255edb3b20053fdd9aa494fa2f6cd6c46b46985650f472f
+    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:115b4d0407d6772ce7ca267eaed7931148a72d59b147a784d6e58ae1876c4214
     container_name: proxy
     networks:
       - front

--- a/eclipse-pass.base.yml
+++ b/eclipse-pass.base.yml
@@ -8,14 +8,14 @@ version: '3.8'
 services:
   auth:
     build: ./sp
-    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:1149308b52a01b83ff490ac01490eaff7440dff8e35828f65093129bda30c6ca
+    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:08d3afb4ee4a7042c97d6d9a889b4adeeff0dfc199fa24d397a1c71830d3be5e
     container_name: auth
     networks:
       - front
       - back
 
   pass-core:
-    image: ghcr.io/eclipse-pass/pass-core-main:0.2.0-SNAPSHOT@sha256:eae7505426547db7b12c6962372a38030deab9567bbbf0cf1fe90629c9457b99
+    image: ghcr.io/eclipse-pass/pass-core-main:0.2.0-SNAPSHOT@sha256:bd0b8b3a79a5e476bed8545c3738b274922e6421be1bd39c5b1a3518a326fb23
     container_name: pass-core
     networks:
       - back

--- a/eclipse-pass.base.yml
+++ b/eclipse-pass.base.yml
@@ -55,7 +55,7 @@ services:
 
   proxy:
     build: ./demo-proxy/
-    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:caeeab82dc9e4f1ca25670bca1d22aaf0488a7fda0226148b0606441a7b042ae
+    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:d58e6e123a922573c255edb3b20053fdd9aa494fa2f6cd6c46b46985650f472f
     container_name: proxy
     networks:
       - front

--- a/eclipse-pass.base.yml
+++ b/eclipse-pass.base.yml
@@ -23,7 +23,7 @@ services:
       - postgres
 
   pass-ui:
-    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:214fac075acc10f37c8aba318463979dba9f47be93a6c4019d2a8a7c57b9f302
+    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:e8a550cca8d906f046995cb3d96f12655c8f6569838364c574a4e604e00a5370
     build:
       context: ./ember
       args:
@@ -55,7 +55,7 @@ services:
 
   proxy:
     build: ./demo-proxy/
-    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:d58e6e123a922573c255edb3b20053fdd9aa494fa2f6cd6c46b46985650f472f
+    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:115b4d0407d6772ce7ca267eaed7931148a72d59b147a784d6e58ae1876c4214
     container_name: proxy
     networks:
       - front

--- a/eclipse-pass.base.yml
+++ b/eclipse-pass.base.yml
@@ -8,7 +8,7 @@ version: '3.8'
 services:
   auth:
     build: ./sp
-    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:08d3afb4ee4a7042c97d6d9a889b4adeeff0dfc199fa24d397a1c71830d3be5e
+    image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:b32633e39b820bb7047a72922934503f71028dcf401396b96522c4535427d830
     container_name: auth
     networks:
       - front
@@ -23,7 +23,7 @@ services:
       - postgres
 
   pass-ui:
-    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:e8a550cca8d906f046995cb3d96f12655c8f6569838364c574a4e604e00a5370
+    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:e78e363a4185ee96c9a83478546c43698f0373d900911d7082c9350ce8aced81
     build:
       context: ./ember
       args:
@@ -55,7 +55,7 @@ services:
 
   proxy:
     build: ./demo-proxy/
-    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:115b4d0407d6772ce7ca267eaed7931148a72d59b147a784d6e58ae1876c4214
+    image: ghcr.io/eclipse-pass/proxy:0.2.0@sha256:07847ef518d96464007aa583f1edbc505bd3221bc5d3d195609d8e1fbfa7822e
     container_name: proxy
     networks:
       - front


### PR DESCRIPTION
Attempt 2 to get the DOI service integrated, following the rebranding changes

* Updated `proxy` to pass `/journal` requests
* Update `pass-auth` to accept `/journal` requests, authenticate, and forward them to `pass-core`
* Update `pass-ui` to use new env var vals
* Changes were made in both `demo.yml` local env and `eclipse-pass.base` deployed envs