### PR TITLE
New sample data loader and ldap entries for demo users

### DIFF
--- a/demo.yml
+++ b/demo.yml
@@ -109,13 +109,13 @@ services:
       context: ./ldap
       args:
         TENANT: jhu
-    image: oapass/ldap:0.1.0@sha256:059f4b287a8a1e8381afeca0e3e13b0255ccf2d93d50d8b318fc8d9826f5d5e5
+    image: ghcr.io/eclipse-pass/demo-ldap:0.2.0@sha256:331cd3ae9c3673c9439fa7465ee807172702bc3dac6583c173766e3c036e8c3e
     container_name: ldap
     networks:
      - back
 
   loader:
-    image: ghcr.io/eclipse-pass/demo-loader:0.2.0@sha256:231b96c7010048b618fbd07ed555547dba98544cc0b4ad96782db4ea4e774f7e
+    image: ghcr.io/eclipse-pass/demo-loader:0.2.0@sha256:a37b48e513f6d86015f62ab39f50b2dc2fc203e6101df1112d73ffb896e23547
     env_file: .demo_env
     container_name: loader
     networks:

--- a/demo.yml
+++ b/demo.yml
@@ -23,7 +23,7 @@ services:
       - postgres
   
   pass-ui:
-    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:e78e363a4185ee96c9a83478546c43698f0373d900911d7082c9350ce8aced81
+    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:300602608acd70e5c0330242f1b7bb5c991f06de70a9260c080f6e641c992bd9
     build:
       context: ./ember
       args:
@@ -115,7 +115,7 @@ services:
      - back
 
   loader:
-    image: ghcr.io/eclipse-pass/demo-loader:0.2.0@sha256:a37b48e513f6d86015f62ab39f50b2dc2fc203e6101df1112d73ffb896e23547
+    image: ghcr.io/eclipse-pass/demo-loader:0.2.0@sha256:d6d559ad9a35e62c4109dff559dc346f700c6f56b516ae666bb03971c7561646
     env_file: .demo_env
     container_name: loader
     networks:

--- a/eclipse-pass.base.yml
+++ b/eclipse-pass.base.yml
@@ -23,7 +23,7 @@ services:
       - postgres
 
   pass-ui:
-    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:e78e363a4185ee96c9a83478546c43698f0373d900911d7082c9350ce8aced81
+    image: ghcr.io/eclipse-pass/pass-ui:0.2.0@sha256:300602608acd70e5c0330242f1b7bb5c991f06de70a9260c080f6e641c992bd9
     build:
       context: ./ember
       args:
@@ -106,13 +106,13 @@ services:
       context: ./ldap
       args:
         TENANT: jhu
-    image: oapass/ldap:0.1.0@sha256:059f4b287a8a1e8381afeca0e3e13b0255ccf2d93d50d8b318fc8d9826f5d5e5
+    image: oapass/ldap:0.1.0@sha256:331cd3ae9c3673c9439fa7465ee807172702bc3dac6583c173766e3c036e8c3e
     container_name: ldap
     networks:
      - back
 
   loader:
-    image: ghcr.io/eclipse-pass/demo-loader:0.2.0@sha256:231b96c7010048b618fbd07ed555547dba98544cc0b4ad96782db4ea4e774f7e
+    image: ghcr.io/eclipse-pass/demo-loader:0.2.0@sha256:d6d559ad9a35e62c4109dff559dc346f700c6f56b516ae666bb03971c7561646
     container_name: loader
     networks:
       - back

--- a/eclipse-pass.base.yml
+++ b/eclipse-pass.base.yml
@@ -106,7 +106,7 @@ services:
       context: ./ldap
       args:
         TENANT: jhu
-    image: oapass/ldap:0.1.0@sha256:331cd3ae9c3673c9439fa7465ee807172702bc3dac6583c173766e3c036e8c3e
+    image: ghcr.io/eclipse-pass/ldap:0.1.0@sha256:331cd3ae9c3673c9439fa7465ee807172702bc3dac6583c173766e3c036e8c3e
     container_name: ldap
     networks:
      - back

--- a/eclipse-pass.base.yml
+++ b/eclipse-pass.base.yml
@@ -106,7 +106,7 @@ services:
       context: ./ldap
       args:
         TENANT: jhu
-    image: ghcr.io/eclipse-pass/ldap:0.1.0@sha256:331cd3ae9c3673c9439fa7465ee807172702bc3dac6583c173766e3c036e8c3e
+    image: ghcr.io/eclipse-pass/demo-ldap:0.2.0@sha256:331cd3ae9c3673c9439fa7465ee807172702bc3dac6583c173766e3c036e8c3e
     container_name: ldap
     networks:
      - back

--- a/ldap/jhu/users.ldif
+++ b/ldap/jhu/users.ldif
@@ -529,3 +529,255 @@ employeeNumber: 99000008
 displayName: Notification Demo BCC Address
 employeeType: STAFF
 homeDirectory: /home/ndemobcc
+
+dn: uid=aforward,ou=People,dc=pass
+uid: aforward
+uidNumber: 7025
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: Andrew
+sn: Forward
+cn: Andrew Forward
+mail: aforward@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0009
+employeeNumber: 99000009
+displayName: aforward@example.com
+employeeType: STAFF
+homeDirectory: /home/aforward
+
+dn: uid=amoore,ou=People,dc=pass
+uid: amoore
+uidNumber: 7026
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: Allen
+sn: Moore
+cn: Allen Moore
+mail: amoore@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0010
+employeeNumber: 99000010
+displayName: amoore@example.com
+employeeType: STAFF
+homeDirectory: /home/amoore
+
+dn: uid=bbranan,ou=People,dc=pass
+uid: bbranan
+uidNumber: 7027
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: Bill
+sn: Branan
+cn: Bill Branan
+mail: bbranan@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0011
+employeeNumber: 99000011
+displayName: bbranan@example.com
+employeeType: STAFF
+homeDirectory: /home/bbranan
+
+dn: uid=grant-mcs,ou=People,dc=pass
+uid: grant-mcs
+uidNumber: 7028
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: Grant
+sn: McSheffrey
+cn: Grant McSheffrey
+mail: grant-mcs@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0012
+employeeNumber: 99000012
+displayName: grant-mcs@example.com
+employeeType: STAFF
+homeDirectory: /home/grant-mcs
+
+dn: uid=jabrah,ou=People,dc=pass
+uid: jabrah
+uidNumber: 7029
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: John
+sn: Abrahams
+cn: John Abrahams
+mail: jabrah@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0013
+employeeNumber: 99000013
+displayName: jabrah@example.com
+employeeType: STAFF
+homeDirectory: /home/jabrah
+
+dn: uid=jaredgalanis,ou=People,dc=pass
+uid: jaredgalanis
+uidNumber: 7030
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: Jared
+sn: Galanis
+cn: Jared Galanis
+mail: jaredgalanis@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0014
+employeeNumber: 99000014
+displayName: jaredgalanis@example.com
+employeeType: STAFF
+homeDirectory: /home/jaredgalanis
+
+dn: uid=jgara,ou=People,dc=pass
+uid: jgara
+uidNumber: 7031
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: Jeff
+sn: Gara
+cn: Jeff Gara
+mail: jgara@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0015
+employeeNumber: 99000015
+displayName: jgara@example.com
+employeeType: STAFF
+homeDirectory: /home/jgara
+
+dn: uid=jrmartino,ou=People,dc=pass
+uid: jrmartino
+uidNumber: 7032
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: Jim
+sn: Martino
+cn: Jim Martino
+mail: jrmartino@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0016
+employeeNumber: 99000016
+displayName: jrmartino@example.com
+employeeType: STAFF
+homeDirectory: /home/jrmartino
+
+dn: uid=kineticsquid,ou=People,dc=pass
+uid: kineticsquid
+uidNumber: 7033
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: John
+sn: Kellerman
+cn: John Kellerman
+mail: kineticsquid@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0017
+employeeNumber: 99000017
+displayName: kineticsquid@example.com
+employeeType: STAFF
+homeDirectory: /home/kineticsquid
+
+dn: uid=markpatton,ou=People,dc=pass
+uid: markpatton
+uidNumber: 7034
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: Mark
+sn: Patton
+cn: Mark Patton
+mail: markpatton@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0018
+employeeNumber: 99000018
+displayName: markpatton@example.com
+employeeType: STAFF
+homeDirectory: /home/markpatton
+
+dn: uid=springstim,ou=People,dc=pass
+uid: springstim
+uidNumber: 7035
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: Tim
+sn: Martin
+cn: Tim Martin
+mail: springstim@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0019
+employeeNumber: 99000019
+displayName: springstim@example.com
+employeeType: STAFF
+homeDirectory: /home/springstim
+
+dn: uid=tsande16,ou=People,dc=pass
+uid: tsande16
+uidNumber: 7036
+gidNumber: 5000
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: eduPerson
+givenName: Tim
+sn: Sanders
+cn: Tim Sanders
+mail: tsande16@example.com
+userPassword: moo
+eduPersonUniqueId: FAKE0020
+employeeNumber: 99000020
+displayName: tsande16@example.com
+employeeType: STAFF
+homeDirectory: /home/tsande16


### PR DESCRIPTION
Resolves https://github.com/eclipse-pass/main/issues/386
Resolves https://github.com/eclipse-pass/main/issues/373
Resolves https://github.com/eclipse-pass/main/issues/389

Deployed to https://demo.eclipse-pass.org/

Add data necessary for some demo users with the usual password. Username is our GH username

* `aforward`
* `amoore`
* `bbranen`
* `grant-mcs`
* `jabrah`
* `jaredgalanis`
* `jgara`
* `jrmartino`
* `kineticsquid`
* `markpatton`
* `springstim`
* `tsande16`

Need to add grants to these users

## Known Bugs

~~Simplest way to add grants is to add all new users as coPis to the same grant. This leads to some bad UI behavior where each coPi on the grant can see the submissions from other users associated with the grant. This means that draft PRs from one coPi can be seen and edited by other coPis :)~~

Workaround should now be in place