### PR TITLE
398 resolve nginx 404

### DIFF
--- a/static-html/Dockerfile
+++ b/static-html/Dockerfile
@@ -14,6 +14,7 @@ RUN cd ${STATIC_HTML_DIR} && \
 
 FROM nginx:1.13.12-alpine
 
+ENV NGINX_404_REDIR_TARGET='$scheme://$host/404.html'
 ENV STATIC_HTML_PORT=80 
 
 COPY --from=static-builder /html/ /usr/share/nginx/html/

--- a/static-html/nginx-template.conf
+++ b/static-html/nginx-template.conf
@@ -5,12 +5,18 @@ server {
     #charset utf-8;
     #access_log  /var/log/nginx/host.access.log  main;
 
+    # error page handler:
+    error_page 404 = @pass404redirect;
+
+    # redirect to top-level 404:
+    location @pass404redirect {
+      return 302 ${NGINX_404_REDIR_TARGET} ;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
     }
-
-    error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html
     #


### PR DESCRIPTION
Note: Due to the way the `envsubst` in this container's startup process rewrites the nginx template file, we couldn't pass any '$' characters to be preserved in the rendered nginx/conf.d/default.conf file (such as $scheme).  So we created an envar with the NGINX rewrite target for 404 as a quoted string rather than a literal within the nginx-template.conf file.  This container envar is rendered by `envsubst` to become a string in the NGINX configuration containing NGINX variables such as '$scheme' and '$host' to specify the redirection target.  The actual /usr/share/nginx/html/404.html is no longer used although it hasn't been removed from the base layer.

Previous logic rendered the 404.html static page in-place that created subsequent 404 redirects for assets expected to be along the original URL path, causing requests such as /x/y/z.html to result in /x/y/404.html which didn't have the context for the assets.