### PR TITLE
Force tests to wait for docker startup

### DIFF
--- a/.github/workflows/pass-acceptance-tests.yml
+++ b/.github/workflows/pass-acceptance-tests.yml
@@ -1,4 +1,5 @@
 name: pass-acceptance-testing
+
 on:
   workflow_dispatch:
   pull_request:
@@ -15,22 +16,22 @@ jobs:
     - name: Checkout pass-docker
       uses: actions/checkout@v3
 
-    - name: Checkout pass-acceptance-testing
-      uses: actions/checkout@v3
-      with:
-        repository: eclipse-pass/pass-acceptance-testing
-        path: pass-acceptance-testing
-    
     - name: Run pass-docker
       run: |
-        docker-compose pull --quiet
-        docker-compose up -d
+        docker compose pull --quiet
+        docker compose up -d
 
     - name: Wait for startup
       run: |
         chmod +x ./wait-to-start.sh
         ./wait-to-start.sh
       shell: bash
+
+    - name: Checkout pass-acceptance-testing
+      uses: actions/checkout@v3
+      with:
+        repository: eclipse-pass/pass-acceptance-testing
+        path: pass-acceptance-testing
 
     - name: Run acceptance tests
       uses: DevExpress/testcafe-action@latest

--- a/.github/workflows/pass-acceptance-tests.yml
+++ b/.github/workflows/pass-acceptance-tests.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
     - name: Append hosts file
       run: echo "127.0.1 pass.local" | sudo tee -a /etc/hosts
+
     - name: Checkout pass-docker
       uses: actions/checkout@v3
 
@@ -19,18 +20,19 @@ jobs:
       with:
         repository: eclipse-pass/pass-acceptance-testing
         path: pass-acceptance-testing
-    - name: Setup Yarn 
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16'
-    - run: yarn install
     
     - name: Run pass-docker
       run: |
-        docker-compose pull
+        docker-compose pull --quiet
         docker-compose up -d
+
+    - name: Wait for startup
+      run: |
+        chmod +x .wait-to-start.sh
+        .wait-to-start.sh
+      shell: bash
 
     - name: Run acceptance tests
       uses: DevExpress/testcafe-action@latest
       with:
-        args: "chrome ./pass-acceptance-testing/tests/*Tests.js"
+        args: "chrome ./pass-acceptance-testing/tests/*Tests.js --selector-timeout 60000 --assertion-timeout 60000 --ajax-request-timeout 60000"

--- a/.github/workflows/pass-acceptance-tests.yml
+++ b/.github/workflows/pass-acceptance-tests.yml
@@ -28,8 +28,8 @@ jobs:
 
     - name: Wait for startup
       run: |
-        chmod +x .wait-to-start.sh
-        .wait-to-start.sh
+        chmod +x ./wait-to-start.sh
+        ./wait-to-start.sh
       shell: bash
 
     - name: Run acceptance tests

--- a/.github/workflows/pass-acceptance-tests.yml
+++ b/.github/workflows/pass-acceptance-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Append hosts file
-      run: echo "127.0.1 pass.local" | sudo tee -a /etc/hosts
+      run: echo "127.0.0.1    pass.local" | sudo tee -a /etc/hosts
 
     - name: Checkout pass-docker
       uses: actions/checkout@v3

--- a/wait-to-start.sh
+++ b/wait-to-start.sh
@@ -1,0 +1,31 @@
+#! /bin/sh
+
+PI_FEDORA_EXTERNAL_BASE="http://pass.local:8080/fcrepo/rest"
+PI_FEDORA_USER="fedoraAdmin"
+PI_FEDORA_PASS="moo"
+PI_MAX_ATTEMPTS=100
+
+CMD="curl -I -u ${PI_FEDORA_USER}:${PI_FEDORA_PASS} --write-out %{http_code} --silent -o /dev/stderr ${PI_FEDORA_EXTERNAL_BASE}"
+echo "Waiting for response from Fedora via 'curl -I -u <u>:<p> ${PI_FEDORA_EXTERNAL_BASE}'"
+
+RESULT=0
+max=${PI_MAX_ATTEMPTS}
+i=1
+
+until [ ${RESULT} -eq 200 ]
+do
+    sleep 5
+    
+    RESULT=$(${CMD})
+
+    if [ $i -eq $max ]
+    then
+        echo "Reached max attempts"
+        exit 1
+    fi
+
+    i=$((i+1))
+    echo "Trying again, result was ${RESULT}"
+done
+
+echo "Fedora is up."

--- a/wait-to-start.sh
+++ b/wait-to-start.sh
@@ -3,7 +3,19 @@
 PI_FEDORA_EXTERNAL_BASE="http://pass.local:8080/fcrepo/rest"
 PI_FEDORA_USER="fedoraAdmin"
 PI_FEDORA_PASS="moo"
-PI_MAX_ATTEMPTS=200
+PI_MAX_ATTEMPTS=100
+
+# curl \
+#     -I \
+#     -u ${PI_FEDORA_USER}:${PI_FEDORA_PASS} \
+#     --write-out ${http_code} \
+#     --silent \
+#     -o /dev/stderr \
+#     --retry 50 \
+#     --retry-delay 5 \
+#     --retry-max-time 300 \
+#     --max-time 10 \
+#     ${PI_FEDORA_EXTERNAL_BASE}
 
 CMD="curl -I -u ${PI_FEDORA_USER}:${PI_FEDORA_PASS} --write-out %{http_code} --silent -o /dev/stderr ${PI_FEDORA_EXTERNAL_BASE}"
 echo "Waiting for response from Fedora via 'curl -I -u <u>:<p> ${PI_FEDORA_EXTERNAL_BASE}'"
@@ -21,7 +33,6 @@ do
     if [ $i -eq $max ]
     then
         echo "Reached max attempts"
-        docker compose ps
         exit 1
     fi
 

--- a/wait-to-start.sh
+++ b/wait-to-start.sh
@@ -3,7 +3,7 @@
 PI_FEDORA_EXTERNAL_BASE="http://pass.local:8080/fcrepo/rest"
 PI_FEDORA_USER="fedoraAdmin"
 PI_FEDORA_PASS="moo"
-PI_MAX_ATTEMPTS=100
+PI_MAX_ATTEMPTS=200
 
 CMD="curl -I -u ${PI_FEDORA_USER}:${PI_FEDORA_PASS} --write-out %{http_code} --silent -o /dev/stderr ${PI_FEDORA_EXTERNAL_BASE}"
 echo "Waiting for response from Fedora via 'curl -I -u <u>:<p> ${PI_FEDORA_EXTERNAL_BASE}'"
@@ -21,6 +21,7 @@ do
     if [ $i -eq $max ]
     then
         echo "Reached max attempts"
+        docker compose ps
         exit 1
     fi
 


### PR DESCRIPTION
* Add wait script that polls Fedora to block execution until Fedora is up
  * Copied from a similar script that forces the `indexer` service to wait to start until fedora and elasticsearch are initialized
  * Intended to poll Fedora every 5 seconds to a max of 100 attempts until a 200 response is received
* Add several Testcafe timeouts to test executions