### PR TITLE
Run acceptance tests against demo env separate from fcrepo env

### DIFF
--- a/.github/workflows/pass-fcrepo-acceptance-tests.yml
+++ b/.github/workflows/pass-fcrepo-acceptance-tests.yml
@@ -1,10 +1,11 @@
 name: pass-acceptance-testing
 
+# On demand only, run tests against Fedora based infrastructure
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
+
+env:
+  PI_FEDORA_EXTERNAL_BASE: "http://pass.local:8080/fcrepo/rest" # Used in the wait script
 
 jobs:
   run_acceptance_tests:
@@ -17,7 +18,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run pass-docker
-      run: ./demo.sh up -d --quiet-pull --no-build --wait
+      run: |
+        docker-compose pull --quiet
+        docker-compose up -d
 
     - name: Wait for startup
       run: |

--- a/demo.sh
+++ b/demo.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose -f demo.yml --env-file .demo_env $@
+docker compose -f demo.yml --env-file .demo_env $@

--- a/wait-to-start.sh
+++ b/wait-to-start.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-PI_FEDORA_EXTERNAL_BASE="http://pass.local:8080/fcrepo/rest"
+PI_FEDORA_EXTERNAL_BASE="${PI_FEDORA_EXTERNAL_BASE:-http://pass.local:8080/data}"
 PI_FEDORA_USER="fedoraAdmin"
 PI_FEDORA_PASS="moo"
 PI_MAX_ATTEMPTS=100
@@ -8,7 +8,7 @@ PI_MAX_ATTEMPTS=100
 # curl \
 #     -I \
 #     -u ${PI_FEDORA_USER}:${PI_FEDORA_PASS} \
-#     --write-out ${http_code} \
+#     --write-out %{http_code} \
 #     --silent \
 #     -o /dev/stderr \
 #     --retry 50 \


### PR DESCRIPTION
* Move tests against old Fedora-based infra into a separate GH action, which will only run manually
* Run tests against demo env on PR against `main` and manually
* Update docker compose calls (`docker-compose >> docker compose`)