### PR TITLE
Make the demo loader simpler

### DIFF
--- a/demo.yml
+++ b/demo.yml
@@ -5,7 +5,6 @@ version: '3.8'
 #   `docker-compose -f demo.yml --env-file .demo_env up`
 services:
   auth:
-    build: ./sp
     image: ghcr.io/eclipse-pass/pass-auth:0.2.0@sha256:c966c8500fe43d90a59839bba2798f9ed9a051c5379783a0971bf700003aeddf
     env_file: .demo_env
     container_name: auth
@@ -124,13 +123,16 @@ services:
      - back
 
   loader:
-    image: ghcr.io/eclipse-pass/demo-loader:0.2.0@sha256:d6d559ad9a35e62c4109dff559dc346f700c6f56b516ae666bb03971c7561646
-    env_file: .demo_env
+    image: curlimages/curl:7.87.0
     container_name: loader
+    command: [curl, http://pass-core:8080/data/, -X, PATCH, -H, "content-type: application/vnd.api+json; ext=jsonpatch", -d, "@/data.json"]
     networks:
       - back
     depends_on:
-      - pass-core
+      pass-core:
+        condition: service_healthy
+    volumes:
+      - ./demo_data.json:/data.json
 
 volumes:
   db:

--- a/demo_data.json
+++ b/demo_data.json
@@ -1,0 +1,1631 @@
+[
+  {
+    "op": "add",
+    "path": "/repository",
+    "value": {
+      "id": "0",
+      "type": "repository",
+      "attributes": {
+        "integrationType": "web-link",
+        "formSchema": "{\"id\":\"eric\",\"schema\":{\"title\":\"Department of Education - ERIC <br><small>Requires deposit to Education Resource Information Center (ERIC).</small><br><br><p class=\"lead text-muted\">Automatic submission from PASS to ERIC is not available at this time. Instead, submission to ERIC will be prompted before this submission is finalized in PASS. The publication information collected so far can be used to complete the submission via the ERIC website.</p>\",\"type\":\"object\",\"properties\":{}},\"options\":{\"fields\":{}}}",
+        "name": "Educational Resources Information Center (ERIC)",
+        "url": "https://eric.ed.gov/",
+        "repositoryKey": "eric"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/repository",
+    "value": {
+      "id": "1",
+      "type": "repository",
+      "attributes": {
+        "agreementText": "NON-EXCLUSIVE LICENSE FOR USE OF MATERIALS This non-exclusive license defines the terms for the deposit of Materials in all formats into the digital repository of materials collected, preserved and made available through the Johns Hopkins Digital Repository, JScholarship. The Contributor hereby grants to Johns Hopkins a royalty free, non-exclusive worldwide license to use, re-use, display, distribute, transmit, publish, re-publish or copy the Materials, either digitally or in print, or in any other medium, now or hereafter known, for the purpose of including the Materials hereby licensed in the collection of materials in the Johns Hopkins Digital Repository for educational use worldwide. In some cases, access to content may be restricted according to provisions established in negotiation with the copyright holder. This license shall not authorize the commercial use of the Materials by Johns Hopkins or any other person or organization, but such Materials shall be restricted to non-profit educational use. Persons may apply for commercial use by contacting the copyright holder. Copyright and any other intellectual property right in or to the Materials shall not be transferred by this agreement and shall remain with the Contributor, or the Copyright holder if different from the Contributor. Other than this limited license, the Contributor or Copyright holder retains all rights, title, copyright and other interest in the images licensed. If the submission contains material for which the Contributor does not hold copyright, the Contributor represents that s/he has obtained the permission of the Copyright owner to grant Johns Hopkins the rights required by this license, and that such third-party owned material is clearly identified and acknowledged within the text or content of the submission. If the submission is based upon work that has been sponsored or supported by an agency or organization other than Johns Hopkins, the Contributor represents that s/he has fulfilled any right of review or other obligations required by such contract or agreement. Johns Hopkins will not make any alteration, other than as allowed by this license, to your submission. This agreement embodies the entire agreement of the parties. No modification of this agreement shall be of any effect unless it is made in writing and signed by all of the parties to the agreement.",
+        "integrationType": "full",
+        "formSchema": "{\"id\":\"JScholarship\",\"schema\":{\"title\":\"Johns Hopkins - JScholarship <br><p class=\"lead text-muted\">Deposit requirements for JH\"s institutional repository JScholarship.</p>\",\"type\":\"object\",\"properties\":{\"authors\":{\"title\":\"<div class=\"row\"><div class=\"col-6\">Author(s) <small class=\"text-muted\">(required)</small></div><div class=\"col-6 p-0\"></div></div>\",\"type\":\"array\",\"uniqueItems\":true,\"items\":{\"type\":\"object\",\"properties\":{\"author\":{\"type\":\"string\",\"fieldClass\":\"body-text col-6 pull-left pl-0\"}}}}}},\"options\":{\"fields\":{\"authors\":{\"hidden\":false}}}}",
+        "name": "JScholarship",
+        "url": "https://jscholarship.library.jhu.edu/",
+        "repositoryKey": "jscholarship"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/repository",
+    "value": {
+      "id": "2",
+      "type": "repository",
+      "attributes": {
+        "integrationType": "web-link",
+        "formSchema": "{\"id\":\"dec\",\"schema\":{\"title\":\"United States Agency for International Development - DEC <br><small>Requires deposit to the Development Experience Clearingshouse (DEC).</small><br><br><p class=\"lead text-muted\">Automatic submission from PASS to ERIC is not available at this time. Instead, submission to DEC will be prompted before this submission is finalized in PASS. The publication information collected so far can be used to complete the submission via the DEC website.</p>\",\"type\":\"object\",\"properties\":{}},\"options\":{\"fields\":{}}}",
+        "name": "Development Experience Clearingshouse (DEC)",
+        "url": "https://dec.usaid.gov/",
+        "repositoryKey": "dec"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/repository",
+    "value": {
+      "id": "3",
+      "type": "repository",
+      "attributes": {
+        "integrationType": "one-way",
+        "formSchema": "{\"id\":\"nih\",\"data\":{},\"schema\":{\"title\":\"NIH Manuscript Submission System (NIHMS) <br><p class=\"lead text-muted\">The following metadata fields will be part of the NIHMS submission.</p>\",\"type\":\"object\",\"properties\":{\"journal-NLMTA-ID\":{\"type\":\"string\"}}},\"options\":{\"fields\":{\"journal-NLMTA-ID\":{\"type\":\"text\",\"label\":\"Journal NLMTA ID\",\"placeholder\":\"\"}}}}",
+        "schemas": [
+          "https://eclipse-pass.github.io/metadata-schemas/jhu/nihms.json",
+          "https://eclipse-pass.github.io/metadata-schemas/jhu/common.json"
+        ],
+        "name": "PubMed Central",
+        "url": "https://www.ncbi.nlm.nih.gov/pmc/",
+        "repositoryKey": "pmc"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "0",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://provost.jhu.edu/about/open-access/",
+        "description": "The university expects that every scholarly article produced by full-time faculty members be accessible in an open access repository. This can be achieved through deposits into existing public access repositoryIds (such as PubMed Central, arXiv, etc.) and/or into Johns Hopkins institutional repository, JScholarship.",
+        "title": "Johns Hopkins University (JHU) Open Access Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "1",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "1",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://www.research.va.gov/resources/policies/public_access.cfm",
+        "description": "The VA requires its investigators to deposit manuscripts in PubMed Central, operated by the National Institutes of Health's National Library of Medicine (NLM), upon the manuscripts' acceptance for publication.  Articles with a publication acceptance date of February 1, 2015, or later are to be included. Deposited manuscripts are made available to the public in PubMed Central no later than 12 months after their publication in a journal",
+        "title": "Department of Veteran Affairs Public Access Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "2",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://ies.ed.gov/funding/researchaccess.asp",
+        "description": "Department of Education requires awardees - grantees or contractors - who are receiving ED funding to carry out research, as well as ED emmployees who produce peer-reviewed scholarly publications, to submit their final peer-reviewed manuscripts to ERIC (Education Resource Information Center) when accepted for publication. Programmatic integration between PASS and ERIC is not available at this time, but a link to ERIC submission portal, along with publication metadata we have collected so far can be found at the end of the submission steps to help you start an article/manuscript submission in ERIC.",
+        "title": "Department of Education IES Policy Regarding Public Access to Research"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "0",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "3",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://www.ahrq.gov/funding/policies/publicaccess/index.html",
+        "description": "The AHRQ Public Access Policy requires that authors of scholarly publications submit the final peer-reviewed accepted journal manuscripts to PubMed Central (PMC). In lieu of the final peer-reviewed manuscript, AHRQ will accept the final published article, provided the awardee can ensure AHRQ has the rights to make the published version public.",
+        "title": "Agency for Healthcare Research and Quality Public Access Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "4",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://www.nasa.gov/sites/default/files/atoms/files/206985_2015_nasa_plan-for-web.pdf",
+        "description": "NASA-funded authors and co-authors (both civil servant and non-civil servant) are required to deposit copies of their peer-reviewed scientific publications and associated data into NASA's publication repository called NASA PubSpace, hosted by PubMed Central, through NIH's Manuscript Submission (NIHMS) System.",
+        "title": "National Aeronautics and Space Administration Public Access Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "5",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://publicaccess.nih.gov/policy.htm",
+        "description": "The Director of the National Institutes of Health requires that all investigators funded by the NIH submit or have submitted for them to the National Library of Medicine's PubMed Central an electronic version of their final, peer-reviewed manuscripts upon acceptance for publication, to be made publicly available no later than 12 months after the official date of publication. In lieu of the final peer-reviewed manuscript, NIH will accept the final published article, provided that the author has the right to submit this version.",
+        "title": "National Institutes of Health Public Access Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "6",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://www.fda.gov/downloads/AboutFDA/ReportsManualsForms/StaffManualGuides/UCM479268.pdf",
+        "description": "The FDA public access policy requires that all FDA-funded research findings published in a peer-reviewed article be made publicly available. The final published article must appear in the National Library of Medicine’s (NLM) PubMed Central (PMC) for free public access to the full-text of the final published article within 12 months of the publication date",
+        "title": "US Food and Drug Administration Public Access Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "7",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://www.hhmi.org/sites/default/files/About/Policies/sc320-public-access-to-publications.pdf",
+        "description": "HHMI strongly encourages all HHMI laboratory heads to publish their original, peer-reviewed research in journals that make publications freely available and downloadable on-line immediately after publication (i.e. open access journals). If a laboratory head chooses to publish an original, peer-reviewed research publication on which he or she is a major author in a journal that is not open access, the laboratory head is responsible for ensuring that the publication is freely available and downloadable on-line as soon as reasonably possible after publication, and in any event within twelve months of publication. \"Major author\" normally includes both the first and last authors; if a middle author is designated in the paper as the corresponding author, then that author is also considered to be a major author. In addition, if an HHMI laboratory head\"s original, peer-reviewed research publication is in a journal in the biological or biomedical sciences, the publication must be available through PubMed Central as soon as reasonably possible, and in any event within twelve months of publication",
+        "title": "Howard Hughes Medical Institute Public Access Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "8",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://www.acl.gov/sites/default/files/about-acl/2017-05/ACL-PublicAcccessPlan-Jan2016.pdf",
+        "description": "The ACL public access plan requires that all peer-reviewed publications generated from ACL-funded research be publicly available via PubMed Central (PMC) no later than 12 months after the official publication date. The peer-reviewed publications may be made available in either the final peer-reviewed article or final peer-reviewed manuscript format.",
+        "title": "Administration for Community Living Public Access Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "9",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://www.phe.gov/Preparedness/planning/science/Documents/AccessPlan.pdf",
+        "description": "ASPR will adapt the National Institutes of Health (NIH) Public Access Policy for eligible ASPR-funded research and require that ASPR-funded investigators submit an electronic version of final peer-reviewed journal manuscripts to the digital archive PubMed Central (PMC) upon acceptance for publication.",
+        "title": "Office of the Assistant Secretary for Preparedness and Response Public Access Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "10",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://www.cdc.gov/maso/Policy/policy596.pdf",
+        "description": "The CDC requires that manuscripts resulting from extramural work must be electronically submitted to the National Institutes of Health (NIH) Manuscript Submission System (NIHMS)",
+        "title": "Centers for Disease Control and Prevention Public Access Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "11",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://ies.ed.gov/funding/researchaccess.asp",
+        "description": "USAID public access policy requires that all peer-reviewed publications produced or funded by USAID must be submitted to the DEC, Development Experience Clearinghouse. Programmatic integration between PASS and the DEC is not available at this time, but a link to the DEC submission portal, along with publication metadata we have collected so far can be found at the end of the submission steps to help you start an article/manuscript submission in the DEC.",
+        "title": "United States Agency for International Development Public Access Plan"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "2",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/funder",
+    "value": {
+      "id": "0",
+      "type": "funder",
+      "attributes": {
+        "localKey": "johnshopkins.edu:funder:300865",
+        "name": "NATIONAL INSTITUTE OF HEALTH"
+      },
+      "relationships": {
+        "policy": {
+          "data": {
+            "id": "5",
+            "type": "policy"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/funder",
+    "value": {
+      "id": "1",
+      "type": "funder",
+      "attributes": {
+        "localKey": "johnshopkins.edu:funder:300852",
+        "name": "NATIONAL EYE INSTITUTE"
+      },
+      "relationships": {
+        "policy": {
+          "data": {
+            "id": "5",
+            "type": "policy"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/funder",
+    "value": {
+      "id": "2",
+      "type": "funder",
+      "attributes": {
+        "localKey": "johnshopkins.edu:funder:311649",
+        "name": "INTERNATIONAL BRAIN RESEARCH"
+      },
+      "relationships": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/funder",
+    "value": {
+      "id": "3",
+      "type": "funder",
+      "attributes": {
+        "localKey": "johnshopkins.edu:funder:301694",
+        "name": "WILLIAM AND ELLA OWENS MEDICAL RESE"
+      },
+      "relationships": {}
+    }
+  },
+  {
+    "op": "add",
+    "path": "/funder",
+    "value": {
+      "id": "4",
+      "type": "funder",
+      "attributes": {
+        "localKey": "johnshopkins.edu:funder:300883",
+        "name": "NATL SCIENCE FOUNDATION"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "0",
+      "type": "user",
+      "attributes": {
+        "displayName": "Nihu Ser",
+        "email": "nihuser@jhu.edu",
+        "firstName": "Nihu",
+        "lastName": "Ser",
+        "locatorIds": [
+          "johnshopkins.edu:jhed:123425",
+          "johnshopkins.edu:hopkinsid:12345",
+          "johnshopkins.edu:employeeid:12345",
+          "johnshopkins.edu:jhed:12345"
+        ],
+        "roles": [
+          "submitter"
+        ],
+        "username": "nih-user@johnshopkins.edu"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "1",
+      "type": "user",
+      "attributes": {
+        "firstName": "Staff",
+        "lastName": "Hasnogrants",
+        "displayName": "Staff Hasnogrants",
+        "roles": [
+          "submitter"
+        ],
+        "locatorIds": [
+          "johnshopkins.edu:jhed:staff2",
+          "johnshopkins.edu:employeeid:1020304",
+          "johnshopkins.edu:hopkinsid:FAKE0002"
+        ],
+        "email": "staffWithNoGrants@jhu.edu",
+        "username": "staff2@johnshopkins.edu"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "2",
+      "type": "user",
+      "attributes": {
+        "firstName": "Staff",
+        "lastName": "Hasgrants",
+        "displayName": "Staff Hasgrants",
+        "roles": [
+          "submitter"
+        ],
+        "locatorIds": [
+          "johnshopkins.edu:jhed:swhg",
+          "johnshopkins.edu:employeeid:906502",
+          "johnshopkins.edu:hopkinsid:FAKESWG"
+        ],
+        "middleName": "Who",
+        "email": "staffWithGrants@jhu.edu",
+        "username": "staff1@johnshopkins.edu"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "3",
+      "type": "user",
+      "attributes": {
+        "firstName": "F",
+        "lastName": "Hasgrants",
+        "displayName": "Faculty Hasgrants",
+        "roles": [
+          "submitter"
+        ],
+        "locatorIds": [
+          "johnshopkins.edu:jhed:fhg1",
+          "johnshopkins.edu:hopkinsid:MF150",
+          "johnshopkins.edu:employeeid:150"
+        ],
+        "middleName": "A",
+        "email": "facultyWithGrants@jhu.edu"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "4",
+      "type": "user",
+      "attributes": {
+        "firstName": "Andrew",
+        "lastName": "Forward",
+        "username": "aforward@johnshopkins.edu",
+        "email": "aforward@johnshopkins.edu",
+        "displayName": "Andrew Forward",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "5",
+      "type": "user",
+      "attributes": {
+        "firstName": "Allen",
+        "lastName": "Moore",
+        "username": "amoore@johnshopkins.edu",
+        "email": "amoore@johnshopkins.edu",
+        "displayName": "Allen Moore",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "6",
+      "type": "user",
+      "attributes": {
+        "firstName": "Bill",
+        "lastName": "Branan",
+        "username": "bbranan@johnshopkins.edu",
+        "email": "bbranan@johnshopkins.edu",
+        "displayName": "Bill Branan",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "7",
+      "type": "user",
+      "attributes": {
+        "firstName": "Grant",
+        "lastName": "McSheffrey",
+        "username": "grant-mcs@johnshopkins.edu",
+        "email": "grant-mcs@johnshopkins.edu",
+        "displayName": "Grant McSheffrey",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "8",
+      "type": "user",
+      "attributes": {
+        "firstName": "John",
+        "lastName": "Abrahams",
+        "username": "jabrah@johnshopkins.edu",
+        "email": "jabrah@johnshopkins.edu",
+        "displayName": "John Abrahams",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "9",
+      "type": "user",
+      "attributes": {
+        "firstName": "Jared",
+        "lastName": "Galanis",
+        "username": "jaredgalanis@johnshopkins.edu",
+        "email": "jaredgalanis@johnshopkins.edu",
+        "displayName": "Jared Galanis",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "10",
+      "type": "user",
+      "attributes": {
+        "firstName": "Jeff",
+        "lastName": "Gara",
+        "username": "jgara@johnshopkins.edu",
+        "email": "jgara@johnshopkins.edu",
+        "displayName": "Jeff Gara",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "11",
+      "type": "user",
+      "attributes": {
+        "firstName": "Jim",
+        "lastName": "Martino",
+        "username": "jrmartino@johnshopkins.edu",
+        "email": "jrmartino@johnshopkins.edu",
+        "displayName": "Jim Martino",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "12",
+      "type": "user",
+      "attributes": {
+        "firstName": "John",
+        "lastName": "Kellerman",
+        "username": "kineticsquid@johnshopkins.edu",
+        "email": "kineticsquid@johnshopkins.edu",
+        "displayName": "John Kellerman",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "13",
+      "type": "user",
+      "attributes": {
+        "firstName": "Mark",
+        "lastName": "Patton",
+        "username": "markpatton@johnshopkins.edu",
+        "email": "markpatton@johnshopkins.edu",
+        "displayName": "Mark Patton",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "14",
+      "type": "user",
+      "attributes": {
+        "firstName": "Tim",
+        "lastName": "Martin",
+        "username": "springstim@johnshopkins.edu",
+        "email": "springstim@johnshopkins.edu",
+        "displayName": "Tim Martin",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/user",
+    "value": {
+      "id": "15",
+      "type": "user",
+      "attributes": {
+        "firstName": "Tim",
+        "lastName": "Sanders",
+        "username": "tsande16@johnshopkins.edu",
+        "email": "tsande16@johnshopkins.edu",
+        "displayName": "Tim Sanders",
+        "roles": [
+          "submitter"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "0",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Print:0095-8301"
+        ],
+        "journalName": "Diabetes forecast",
+        "nlmta": "Diabetes Forecast"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "1",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Online:1945-0508",
+          "Print:1945-0494"
+        ],
+        "journalName": "Frontiers in bioscience (Elite edition)",
+        "nlmta": "Front Biosci (Elite Ed)"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "2",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Online:2090-6412",
+          "Print:2090-6404"
+        ],
+        "journalName": "Case Reports in Cardiology",
+        "pmcParticipation": "A",
+        "nlmta": "Case Rep Cardiol"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "3",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Print:0046-2233"
+        ],
+        "journalName": "Environmental biology and medicine",
+        "nlmta": "Environ Biol Med"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "4",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Print:0367-3480"
+        ],
+        "journalName": "Frankfurter Zeitschrift fur Pathologie",
+        "nlmta": "Frankf Z Pathol"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "5",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Print:0001-723X",
+          "Online:1336-2305"
+        ],
+        "journalName": "Acta virologica",
+        "nlmta": "Acta Virol"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "6",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Print:1784-9934"
+        ],
+        "journalName": "Journal of cyber therapy and rehabilitation",
+        "nlmta": "J Cyber Ther Rehabil"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "7",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Print:0559-1996"
+        ],
+        "journalName": "Report of proceedings. Scottish Society of the History of Medicine",
+        "nlmta": "Rep Proc Scott Soc Hist Med"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "8",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Print:0952-3367"
+        ],
+        "journalName": "The International journal of the history of sport",
+        "nlmta": "Int J Hist Sport"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "9",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Print:0967-0874",
+          "Online:1366-5863"
+        ],
+        "journalName": "International journal of pest management",
+        "nlmta": "Int J Pest Manag"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/publication",
+    "value": {
+      "id": "0",
+      "type": "publication",
+      "attributes": {
+        "volume": "23",
+        "issue": "7",
+        "pmid": "25820114",
+        "title": "Is There Excess Oxidative Stress and Damage in Eyes of Patients with Retinitis Pigmentosa?",
+        "doi": "10.1089/ars.2015.6327"
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/publication",
+    "value": {
+      "id": "1",
+      "type": "publication",
+      "attributes": {
+        "volume": "86",
+        "issue": "2",
+        "title": "Balancing Excitation and Inhibition",
+        "doi": "10.1016/j.neuron.2015.04.009"
+      },
+      "relationships": {
+        "journal": {
+          "data": {
+            "id": "1",
+            "type": "journal"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/publication",
+    "value": {
+      "id": "2",
+      "type": "publication",
+      "attributes": {
+        "volume": "0",
+        "issue": "",
+        "title": "This is a test publication",
+        "doi": ""
+      },
+      "relationships": {
+        "journal": {
+          "data": {
+            "id": "6",
+            "type": "journal"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "0",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2022-06-30T00:00:00.000Z",
+        "awardNumber": "R01EY012124",
+        "awardDate": "2017-05-26T00:00:00.000Z",
+        "awardStatus": "active",
+        "projectName": "Regulation of Synaptic Plasticity in Visual Cortex",
+        "startDate": "2017-07-01T00:00:00.000Z",
+        "localKey": "johnshopkins.edu:grant:12345"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "0",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "0",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "1",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2018-08-31T00:00:00.000Z",
+        "awardNumber": "Z0650001",
+        "awardDate": "2015-09-23T00:00:00.000Z",
+        "awardStatus": "active",
+        "projectName": "Reversible activation of critical period plasticity in visual cortex",
+        "startDate": "2015-09-01T00:00:00.000Z",
+        "localKey": "johnshopkins.edu:grant:12345"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "1",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "1",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "2",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2018-03-31T00:00:00.000Z",
+        "awardNumber": "90072705",
+        "awardDate": "2017-01-20T00:00:00.000Z",
+        "awardStatus": "terminated",
+        "projectName": "IBRO-USCRC North American Research Fellowship",
+        "startDate": "2017-04-01T00:00:00.000Z",
+        "localKey": "johnshopkins.edu:grant:12345"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "2",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "2",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "3",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2017-06-30T00:00:00.000Z",
+        "awardNumber": "R01EY012124",
+        "awardDate": "2013-07-22T00:00:00.000Z",
+        "awardStatus": "terminated",
+        "projectName": "Regulation of Synaptic Plasticity in Visual Cortex",
+        "startDate": "2013-08-01T00:00:00.000Z",
+        "localKey": "johnshopkins.edu:grant:12345"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "1",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "1",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "4",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2017-06-30T00:00:00.000Z",
+        "awardNumber": "R01EY012124",
+        "awardDate": "2015-05-01T00:00:00.000Z",
+        "awardStatus": "terminated",
+        "projectName": "Admin. Supplement - Regulation of Synaptic Plasticity in Visual Cortex",
+        "startDate": "2013-08-01T00:00:00.000Z",
+        "localKey": "johnshopkins.edu:grant:12345"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "1",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "1",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "5",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2017-01-31T00:00:00.000Z",
+        "awardNumber": "90067366",
+        "awardDate": "2015-12-21T00:00:00.000Z",
+        "awardStatus": "terminated",
+        "projectName": "Metaplasticity in a Transgenic Mouse Model of Alzheimer Disease",
+        "startDate": "2016-02-01T00:00:00.000Z",
+        "localKey": "johnshopkins.edu:grant:12345"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "3",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "3",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "6",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2015-07-31T00:00:00.000Z",
+        "awardNumber": "P01AG009973",
+        "awardDate": "2008-03-31T00:00:00.000Z",
+        "awardStatus": "terminated",
+        "projectName": "Cognition and Hippocampal/ Cortical Systems in Aging",
+        "startDate": "2008-04-01T00:00:00.000Z",
+        "localKey": "johnshopkins.edu:grant:12345"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "coPis": {
+          "data": [
+            {
+              "id": "0",
+              "type": "user"
+            },
+            {
+              "id": "4",
+              "type": "user"
+            },
+            {
+              "id": "5",
+              "type": "user"
+            },
+            {
+              "id": "6",
+              "type": "user"
+            },
+            {
+              "id": "7",
+              "type": "user"
+            },
+            {
+              "id": "8",
+              "type": "user"
+            },
+            {
+              "id": "9",
+              "type": "user"
+            },
+            {
+              "id": "10",
+              "type": "user"
+            },
+            {
+              "id": "11",
+              "type": "user"
+            },
+            {
+              "id": "12",
+              "type": "user"
+            },
+            {
+              "id": "13",
+              "type": "user"
+            },
+            {
+              "id": "14",
+              "type": "user"
+            },
+            {
+              "id": "15",
+              "type": "user"
+            }
+          ]
+        },
+        "directFunder": {
+          "data": {
+            "id": "0",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "0",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "7",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2015-07-31T00:00:00.000Z",
+        "awardNumber": "R01AG034606",
+        "awardDate": "2009-08-14T00:00:00.000Z",
+        "awardStatus": "terminated",
+        "projectName": "Synaptic Function & Plasticity in CA3 Circuits in the Aging Hippocampus",
+        "startDate": "2009-08-15T00:00:00.000Z",
+        "localKey": "johnshopkins.edu:grant:12345"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "0",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "0",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "8",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2013-07-31T00:00:00.000Z",
+        "awardNumber": "R01EY012124",
+        "awardDate": "2008-11-24T00:00:00.000Z",
+        "awardStatus": "terminated",
+        "projectName": "Regulation of Synaptic Plasticity in Visual Cortex",
+        "startDate": "2008-12-01T00:00:00.000Z",
+        "localKey": "johnshopkins.edu:grant:12345"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "0",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "0",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "9",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2022-06-30T00:00:00.000Z",
+        "startDate": "2017-07-01T00:00:00.000Z",
+        "awardDate": "2017-05-26T00:00:00.000Z",
+        "awardNumber": "QQDV123P7",
+        "awardStatus": "active",
+        "projectName": "Eye research",
+        "localKey": "johnshopkins.edu:grant:126449"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "0",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "0",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "10",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2021-07-31T00:00:00.000Z",
+        "startDate": "2017-07-01T00:00:00.000Z",
+        "awardDate": "2009-08-04T00:00:00.000Z",
+        "awardNumber": "R124",
+        "awardStatus": "terminated",
+        "projectName": "Eye research",
+        "localKey": "johnshopkins.edu:grant:106501"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "2",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "4",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "4",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/submission",
+    "value": {
+      "id": "0",
+      "type": "submission",
+      "attributes": {
+        "submitted": false,
+        "submissionStatus": "manuscript-required",
+        "aggregatedDepositStatus": "not-started",
+        "source": "other"
+      },
+      "relationships": {
+        "grants": {
+          "data": [
+            {
+              "id": "0",
+              "type": "grant"
+            }
+          ]
+        },
+        "submitter": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "effectivePolicies": {
+          "data": [
+            {
+              "id": "5",
+              "type": "policy"
+            },
+            {
+              "id": "0",
+              "type": "policy"
+            }
+          ]
+        },
+        "repositories": {
+          "data": [
+            {
+              "id": "1",
+              "type": "repository"
+            },
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        },
+        "publication": {
+          "data": {
+            "id": "1",
+            "type": "publication"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/submission",
+    "value": {
+      "id": "1",
+      "type": "submission",
+      "attributes": {
+        "submitted": true,
+        "submissionStatus": "complete",
+        "source": "other"
+      },
+      "relationships": {
+        "grants": {
+          "data": [
+            {
+              "id": "6",
+              "type": "grant"
+            }
+          ]
+        },
+        "submitter": {
+          "data": {
+            "id": "3",
+            "type": "user"
+          }
+        },
+        "repositories": {
+          "data": [
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        },
+        "publication": {
+          "data": {
+            "id": "0",
+            "type": "publication"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/submission",
+    "value": {
+      "id": "2",
+      "type": "submission",
+      "attributes": {
+        "submitted": false,
+        "submissionStatus": "approval-requested",
+        "aggregatedDepositStatus": "not-started",
+        "source": "other"
+      },
+      "relationships": {
+        "grants": {
+          "data": [
+            {
+              "id": "0",
+              "type": "grant"
+            }
+          ]
+        },
+        "submitter": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "effectivePolicies": {
+          "data": [
+            {
+              "id": "5",
+              "type": "policy"
+            },
+            {
+              "id": "0",
+              "type": "policy"
+            }
+          ]
+        },
+        "repositories": {
+          "data": [
+            {
+              "id": "1",
+              "type": "repository"
+            },
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        },
+        "publication": {
+          "data": {
+            "id": "2",
+            "type": "publication"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/submission",
+    "value": {
+      "id": "3",
+      "type": "submission",
+      "attributes": {
+        "submitted": false,
+        "submissionStatus": "cancelled",
+        "aggregatedDepositStatus": "not-started",
+        "source": "other"
+      },
+      "relationships": {
+        "grants": {
+          "data": [
+            {
+              "id": "0",
+              "type": "grant"
+            }
+          ]
+        },
+        "submitter": {
+          "data": {
+            "id": "0",
+            "type": "user"
+          }
+        },
+        "effectivePolicies": {
+          "data": [
+            {
+              "id": "5",
+              "type": "policy"
+            },
+            {
+              "id": "0",
+              "type": "policy"
+            }
+          ]
+        },
+        "repositories": {
+          "data": [
+            {
+              "id": "1",
+              "type": "repository"
+            },
+            {
+              "id": "3",
+              "type": "repository"
+            }
+          ]
+        },
+        "publication": {
+          "data": {
+            "id": "2",
+            "type": "publication"
+          }
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
This pr changes the demo data loading such that it doesn't need a custom image. 
Instead the Elide batch ingest functionality is used. I transformed demo data into the batch format. A curl image does pushes the data to Elide after waiting for Elide to start.

This can be tested by doing a `docker compose -f demo.yml up` and making sure the demo data gets ingested.