### PR TITLE
Run acceptance tests on push to main

### DIFF
--- a/.github/workflows/pass-acceptance-tests.yml
+++ b/.github/workflows/pass-acceptance-tests.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 env:
   TIMEOUT_LENGTH: 120000


### PR DESCRIPTION
Acceptance tests are currently only run on PRs, but we should also be running them on pushes to `main`