### PR TITLE
Update healthcheck and loader to act as backend user

### DIFF
--- a/.env
+++ b/.env
@@ -21,6 +21,9 @@ PASS_CORE_BASE_URL=https://pass.local
 # Automatically create database tables
 PASS_CORE_JAVA_OPTS="-Djavax.persistence.schema-generation.database.action=create"
 
+PASS_CORE_BACKEND_USER=backend
+PASS_CORE_BACKEND_PASSWORD=backend
+
 ###################################################
 # PASS_UI config ##################################
 # ## Changes here require new image build #########

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     depends_on:
       - postgres
     healthcheck:
-      test: "curl -f http://pass-core:8080/data/user || exit 1"
+      test: "curl -u $PASS_CORE_BACKEND_USER:$PASS_CORE_BACKEND_PASSWORD -f http://pass-core:8080/data/user || exit 1"
       start_period: 30s
 
   pass-ui:
@@ -137,7 +137,7 @@ services:
   loader:
     image: curlimages/curl:7.87.0
     container_name: loader
-    command: [curl, http://pass-core:8080/data/, -X, PATCH, -H, "content-type: application/vnd.api+json; ext=jsonpatch", -d, "@/data.json"]
+    command: [curl, http://pass-core:8080/data/, -u, "$PASS_CORE_BACKEND_USER:$PASS_CORE_BACKEND_PASSWORD", -X, PATCH, -H, "content-type: application/vnd.api+json; ext=jsonpatch", -d, "@/data.json"]
     networks:
       - back
     depends_on:


### PR DESCRIPTION
This pr updates the healthcheck and loader scripts to act as the backend user.
In order to test, bring up docker environment and verify that objects have been loaded in.
This should work with pass-core 0.3.0 (no access control) and 0.4.0 (access control).