### PR TITLE
516 docker image automation

### DIFF
--- a/.github/workflows/deploy_passnightly.yml
+++ b/.github/workflows/deploy_passnightly.yml
@@ -31,14 +31,10 @@ jobs:
 
       - name: Stop Existing App
         run: |
-          # Stop the application, but then also  all docker compose projects, containers, images, etc. for a clean start:
-          docker-compose -f docker-compose.yml -f eclipse-pass.nightly.yml down
+          # Stop the application, but then also all docker compose projects, containers, images, etc. for a clean start:
+          docker compose -f docker-compose.yml -f eclipse-pass.nightly.yml down
           bash ./tools/docker/stopall.sh
-
-      - name: Build App
-        run: |
-          docker-compose -f docker-compose.yml -f eclipse-pass.nightly.yml pull
 
       - name: Run App
         run: |
-          docker-compose -f docker-compose.yml -f eclipse-pass.nightly.yml up -d
+          docker compose -f docker-compose.yml -f eclipse-pass.nightly.yml up -d --no-build --pull always

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -1,0 +1,44 @@
+  # Update Docker images in pass-docker that are build in this repository:
+  #   * proxy
+  #   * pass-ui-public
+  #   * idp
+  #   * ldap
+name: update-docker-images
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # get-version:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     project-version: ${{ steps.project-version.outputs.version }}
+  #   steps:
+  #     - id: project-version
+  #       run: echo "VERSION=grep -Po '(?<=PASS_VERSION=).* .env" >> $GITHUB_OUTPUT
+  update-images:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build set of Docker images
+        run: docker compose build --no-cache proxy pass-ui-public idp ldap
+
+      - name: Publish Docker images
+        run: docker compose push proxy pass-ui-public idp ldap

--- a/eclipse-pass.nightly.yml
+++ b/eclipse-pass.nightly.yml
@@ -8,7 +8,6 @@ services:
       - .eclipse-pass.nightly_env
 
   pass-core:
-    image: ghcr.io/eclipse-pass/pass-core-main:0.5.0-SNAPSHOT@sha256:6e8d64544fde2d52995e8b5c93ad409283961d38625ea79e40b959f4b6c9defe
     env_file:
       - .eclipse-pass.nightly_env
 


### PR DESCRIPTION
* New automation to build and publish new Docker images for `proxy`, `pass-ui-public`, `idp`, and `ldap` on pushes to main branch
  * A bit overeager, as it should only need to be done when there are changes to these images that need updating
* Update `nightly` compose setup to strip Docker image hashes and always pull the latest based on the base compose setup
  * This behavior is enabled because of updated automation in `pass-core`, `pass-ui`, and `pass-auth` that will now publish updated Docker images based on the current project version (right now: `0.5.0-SNAPSHOT`)