### PR TITLE
chore: remove pass-ui-public

### DIFF
--- a/.env
+++ b/.env
@@ -86,7 +86,7 @@ AUTH_LOGIN="/login/:idpId"
 AUTH_LOGIN_SUCCESS=/app/auth-callback
 AUTH_LOGIN_FAILURE=/
 AUTH_LOGOUT=/logout
-AUTH_LOGOUT_REDIRECT=/
+AUTH_LOGOUT_REDIRECT="/login/saml"
 
 SESSION_SECRET="J6@NXHe!6ANivq*kp2xVL.hmuMsPQ@2XWTJpzN3YANXDNFGfVUmm.m_gEvXaLstuoPCZQwUv4CmFb-4jo*VyARkBpPqLzqFi2aiX"
 
@@ -97,18 +97,6 @@ SESSION_SECRET="J6@NXHe!6ANivq*kp2xVL.hmuMsPQ@2XWTJpzN3YANXDNFGfVUmm.m_gEvXaLstu
 LOADER_API_HOST=http://pass-core
 LOADER_API_PORT=8080
 LOADER_API_NAMESPACE=data
-
-###################################################
-# Static HTML config ##############################
-###################################################
-
-# Static html server runtime config
-STATIC_CONFIG_URI=/config.json
-STATIC_HTML_PORT=82
-
-# Static html server build-time config
-STATIC_HTML_GIT_REPO=https://github.com/eclipse-pass/pass-ui-public
-STATIC_HTML_GIT_BRANCH=main
 
 ###################################################
 # LDAP / Mail server config #######################

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           version: $RELEASE
       
       - name: Build new images
-        run: docker compose build proxy pass-ui-public idp ldap
+        run: docker compose build proxy idp ldap
 
       - name: Acceptance tests
         if: ${{ inputs.runtests }}
@@ -52,7 +52,7 @@ jobs:
           pullimages: 'missing'
 
       - name: Push release images
-        run: docker compose push proxy pass-ui-public idp ldap
+        run: docker compose push proxy idp ldap
 
       - name: Bump image versions to next development version
         uses: ./.github/actions/update-pass-version
@@ -67,5 +67,5 @@ jobs:
         run: git push origin $RELEASE
 
       - name: Build and push next development image tags
-        run: docker compose build --push proxy pass-ui-public idp ldap
+        run: docker compose build --push proxy idp ldap
 

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -1,6 +1,5 @@
   # Update Docker images in pass-docker that are build in this repository:
   #   * proxy
-  #   * pass-ui-public
   #   * idp
   #   * ldap
 name: update-docker-images
@@ -38,7 +37,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Build set of Docker images
-        run: docker compose build --no-cache proxy pass-ui-public idp ldap
+        run: docker compose build --no-cache proxy idp ldap
 
       - name: Publish Docker images
-        run: docker compose push proxy pass-ui-public idp ldap
+        run: docker compose push proxy idp ldap

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Environment variables:
 * `AUTH_LOGIN_SUCCESS=/app/auth-callback`
 * `AUTH_LOGIN_FAILURE=/`
 * `AUTH_LOGOUT=/logout`
-* `AUTH_LOGOUT_REDIRECT=/` : The location to redirect to after a logout occurs. In the default `pass-docker` setup `/` resolves to the `pass-ui-public` pages. This can be configured to redirect to an IDP. To configure this to redirect to the demo IDP use `/login/saml` as the value.
+* `AUTH_LOGOUT_REDIRECT=/login/saml` : The location to redirect to after a logout occurs.
 * `FORCE_AUTHN=true`
 * `SIGNING_CERT_IDP="..."`
 * `SAML_ENTRY_POINT="https://pass.local/idp/profile/SAML2/Redirect/SSO"` : absolute URL must change for different environments

--- a/demo-proxy/etc-httpd/conf.d/httpd.conf
+++ b/demo-proxy/etc-httpd/conf.d/httpd.conf
@@ -63,11 +63,14 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     ProxyPassReverse /idp https://idp:4443/idp
 
    # Mapping some auth routes
+    ProxyPass / http://auth:3000/
+    ProxyPassReverse / http://auth:3000/
+
     ProxyPass /login http://auth:3000/login
     ProxyPassReverse /login http://auth:3000/login
 
-    ProxyPass /Shibboleth.sso http://auth:3000/Shibboleth.sso
-    ProxyPassReverse /Shibboleth.sso http://auth:3000/Shibboleth.sso
+    ProxyPass /Shibboleth.sso http://auth:3000/Shibboleth.sso/SAML2/POST/saml
+    ProxyPassReverse /Shibboleth.sso http://auth:3000/Shibboleth.sso/SAML2/POST/saml
 
     ProxyPass /metadata http://auth:3000/metadata
     ProxyPassReverse /metadata http://auth:3000/metadata
@@ -107,10 +110,6 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     # Policy service
     ProxyPass /policy http://auth:3000/policy
     ProxyPassReverse /policy http://auth:3000/policy
-
-    # Static pages
-    ProxyPass / http://pass-ui-public:82/
-    ProxyPassReverse / http://pass-ui-public:82/
 
 </VirtualHost>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,21 +80,6 @@ services:
       - "80:80"
       - "443:443"
 
-  pass-ui-public:
-    build:
-      context: ./static-html
-      args:
-        STATIC_HTML_GIT_REPO: "${STATIC_HTML_GIT_REPO}"
-        STATIC_HTML_GIT_BRANCH: "${STATIC_HTML_GIT_BRANCH}"
-    image: "ghcr.io/eclipse-pass/pass-ui-public:${PASS_VERSION}"
-    container_name: pass-ui-public
-    env_file:
-      - .env
-    ports:
-      - "${STATIC_HTML_PORT}:${STATIC_HTML_PORT}"
-    networks:
-      - front
-
   idp:
     build:
       context: ./idp

--- a/eclipse-pass.JHUAWSdemo.yml
+++ b/eclipse-pass.JHUAWSdemo.yml
@@ -19,10 +19,6 @@ services:
     env_file:
       - .eclipse-pass.JHUAWSdemo_env
 
-  pass-ui-public:
-    env_file:
-      - .eclipse-pass.JHUAWSdemo_env
-
   idp:
     env_file:
       - .eclipse-pass.JHUAWSdemo_env

--- a/eclipse-pass.demo.yml
+++ b/eclipse-pass.demo.yml
@@ -19,10 +19,6 @@ services:
     env_file:
       - .eclipse-pass.demo_env
 
-  pass-ui-public:
-    env_file:
-      - .eclipse-pass.demo_env
-
   idp:
     env_file:
       - .eclipse-pass.demo_env

--- a/eclipse-pass.local.yml
+++ b/eclipse-pass.local.yml
@@ -20,10 +20,6 @@ services:
     env_file:
       - .eclipse-pass.local_env
 
-  pass-ui-public:
-    env_file:
-      - .eclipse-pass.local_env
-
   idp:
     env_file:
       - .eclipse-pass.local_env

--- a/eclipse-pass.nightly.yml
+++ b/eclipse-pass.nightly.yml
@@ -19,10 +19,6 @@ services:
     env_file:
       - .eclipse-pass.nightly_env
 
-  pass-ui-public:
-    env_file:
-      - .eclipse-pass.nightly_env
-
   idp:
     env_file:
       - .eclipse-pass.nightly_env


### PR DESCRIPTION
- we have decided to remove pass-ui-public from pass-docker since https://github.com/eclipse-pass/eclipse-pass.github.io provides the public pages for the eclipse-pass community version of the application and JHU pages will be supported in JHU repositories and JHU infra
- this means the root URL of pass-docker will be the IDP login page