### PR TITLE
Fix demo deploy volume dir permission issue

### DIFF
--- a/eclipse-pass.local.yml
+++ b/eclipse-pass.local.yml
@@ -100,7 +100,7 @@ services:
       - ./demo_data.json:/data.json
 
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "localstack"
     image: localstack/localstack:2.1.0
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
@@ -108,8 +108,6 @@ services:
     environment:
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
-      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
-      - "/var/run/docker.sock:/var/run/docker.sock"
       - "./localstack/sqs_bootstrap.sh:/etc/localstack/init/ready.d/init-aws.sh"
     networks:
       - back


### PR DESCRIPTION
Localstack was creating the ./volume dir as root user, causing an issue in the deploy script.  This volume is not needed since we don't persist any data between in localstack between deployments, so just removed all together.