### PR TITLE
671 Change the Credentials in Deposit-Repositories

### DIFF
--- a/.eclipse-pass.JHUAWSstage_env.template
+++ b/.eclipse-pass.JHUAWSstage_env.template
@@ -35,11 +35,14 @@ PASS_CLIENT_URL=http://stage-pass-core:8080/
 PASS_CLIENT_USER=stagepasscoreuser
 PASS_CLIENT_PASSWORD=stagepasscorepassword
 
-DSPACE_HOST=dspace
-DSPACE_PORT=8080
+DSPACE_SERVER=dspace:8080
+DSPACE_USER=test@test.edu
+DSPACE_PASSWORD=admin
 
-FTP_HOST=pmc-ftp-server
-FTP_PORT=21
+PMC_FTP_HOST=pmc-ftp-server
+PMC_FTP_PORT=21
+PMC_FTP_USER=nihmsftpuser
+PMC_FTP_PASSWORD=nihmsftppass
 
 ###################################################
 # Auth / Proxy config #############################

--- a/.eclipse-pass.local_env
+++ b/.eclipse-pass.local_env
@@ -32,11 +32,14 @@ PASS_CLIENT_URL=http://pass-core:8080/
 PASS_CLIENT_USER=backend
 PASS_CLIENT_PASSWORD=backend
 
-DSPACE_HOST=dspace
-DSPACE_PORT=8080
+DSPACE_SERVER=dspace:8080
+DSPACE_USER=test@test.edu
+DSPACE_PASSWORD=admin
 
-FTP_HOST=pmc-ftp-server
-FTP_PORT=21
+PMC_FTP_HOST=pmc-ftp-server
+PMC_FTP_PORT=21
+PMC_FTP_USER=nihmsftpuser
+PMC_FTP_PASSWORD=nihmsftppass
 
 ###################################################
 # Auth / Proxy config #############################

--- a/deposit/deposit-repositories.json
+++ b/deposit/deposit-repositories.json
@@ -26,19 +26,19 @@
       "auth-realms": [
         {
           "mech": "basic",
-          "username": "test@test.edu",
-          "password": "admin",
-          "url": "http://${dspace.host}:${dspace.port}/server/swordv2"
+          "username": "${dspace.user}",
+          "password": "${dspace.password}",
+          "url": "http://${dspace.server}/server/swordv2"
         }
       ],
       "protocol-binding": {
         "protocol": "SWORDv2",
-        "username": "test@test.edu",
-        "password": "admin",
-        "server-fqdn": "${dspace.host}",
-        "server-port": "${dspace.port}",
-        "service-doc": "http://${dspace.host}:${dspace.port}/server/swordv2/servicedocument",
-        "default-collection": "http://${dspace.host}:${dspace.port}/server/swordv2/collection/123456789/20",
+        "username": "${dspace.user}",
+        "password": "${dspace.password}",
+        "server-fqdn": null,
+        "server-port": null,
+        "service-doc": "http://${dspace.server}/server/swordv2/servicedocument",
+        "default-collection": "http://${dspace.server}/server/swordv2/collection/123456789/20",
         "on-behalf-of": null,
         "deposit-receipt": true,
         "user-agent": "pass-deposit/x.y.z"
@@ -71,10 +71,10 @@
     "transport-config": {
       "protocol-binding": {
         "protocol": "ftp",
-        "username": "nihmsftpuser",
-        "password": "nihmsftppass",
-        "server-fqdn": "${ftp.host}",
-        "server-port": "${ftp.port}",
+        "username": "${pmc.ftp.user}",
+        "password": "${pmc.ftp.password}",
+        "server-fqdn": "${pmc.ftp.host}",
+        "server-port": "${pmc.ftp.port}",
         "data-type": "binary",
         "transfer-mode": "stream",
         "use-pasv": true,


### PR DESCRIPTION
The separate `server-fqdn` and `server-port` were not working for the SWORDv2 transport in the deposit-repositories.json. These variables have been set to null and are replaced with a new environment variable `dspace.server` in pass-docker. In order to achieve this in `pass-support` there were two new variables added in the application.properties: dspace.user and dspace.password

This is related to PR: https://github.com/eclipse-pass/pass-support/pull/51

Both this PR in `pass-docker` and the PR in `pass-support` need to be checked out to test locally.

Other things to note:

- Change the environment variable FTP_HOST to PMC_FTP_HOST

Testing:

- Run pass-docker and pull images, but remove the deposit-services-core image
    - `docker compose -f docker-compose.yml -f eclipse-pass.local.yml up -d --no-build --quiet-pull --pull always`
    - After retrieving all images. Bring pass-docker down and remove all volumes
        - `docker compose -p pass-docker down -v`
    - Remove the image deposit-services-core
- Create the deposit-services-core image locally.
- Run pass-docker without pulling images and include the deposit-services, dspace and ftp
    - `docker compose -p pass-docker -f docker-compose.yml -f eclipse-pass.local.yml -f docker-compose-deposit.yml -f docker-compose-dspace.yml up -d --no-build`
- Create the Admin:
    - `docker compose -p pass-docker -f dspace-cli.yml run --rm dspace-cli create-administrator -e test@test.edu -f admin -l user -p admin -c en`
- Load sample data:
    - `docker compose -p pass-docker -f dspace-cli.yml -f dspace-cli.ingest.yml run --rm dspace-cli`

