### PR TITLE
Update for pass-core liquibase

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ PASS_CORE_PORT=8080
 spring_profiles_active=production
 
 # Automatically create database tables
-PASS_CORE_JAVA_OPTS="-Djavax.persistence.schema-generation.database.action=create"
+PASS_CORE_JAVA_OPTS=""
 
 PASS_CORE_USE_SQS=true
 PASS_CORE_EMBED_JMS_BROKER=false


### PR DESCRIPTION
Small change to turn on javax.pers auto ddl setting because liquibase is being used going forward.

This PR is dependent on https://github.com/eclipse-pass/pass-core/pull/54