### PR TITLE
fix: pin test cafe to 3.3.0

### DIFF
--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -33,6 +33,7 @@ runs:
     - name: Run acceptance tests
       uses: DevExpress/testcafe-action@latest
       with:
+        version: "3.3.0"
         args: "'chrome --ignore-certificate-errors --allow-insecure-localhost' --hostname localhost ./pass-acceptance-testing/tests/*Tests.js --selector-timeout ${{ inputs.timeouts}} --assertion-timeout ${{ inputs.timeouts}} --ajax-request-timeout ${{ inputs.timeouts}}"
 
     - name: Stop pass-docker


### PR DESCRIPTION
- we've had some problems getting acceptance tests to pass in the release workflow since test cafe 3.4.0 was released 3 weeks ago
- the last release used version 3.3.0 and was successful
- so this pins to that version