### PR TITLE
Change CORS Access Control headers in proxy server

### DIFF
--- a/demo-proxy/etc-httpd/conf.d/httpd.conf
+++ b/demo-proxy/etc-httpd/conf.d/httpd.conf
@@ -50,13 +50,8 @@ EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"
     #Header set Strict-Transport-Security "max-age=300"
     #Header set Content-Security-Policy: upgrade-insecure-requests
 
-    Header set Access-Control-Max-Age "300"
-    # could be 'localhost', <ip-of-docker-machine>, '</etc/hosts entry>'
-    Header set Access-Control-Allow-Origin "*"
-    # allow cookies to be sent cross origin
-    Header set Access-Control-Allow-Credentials "true"
+    Header set Access-Control-Allow-Origin "${PASS_CORE_BASE_URL}"
     Header merge Access-Control-Allow-Methods "PUT, OPTIONS"
-    Header merge Access-Control-Expose-Headers "authorization"
 
     #Map /idp to Tomcat
     ProxyPass /idp https://idp:4443/idp


### PR DESCRIPTION
The `Access-Control-Allow-Origin` header was set to `*` allowing any domain to make a CORS request.  I have changed this so that the `Access-Control-Allow-Origin` will be set to `https://domainname`.

I also removed the access control headers since allowing the browser to default is recommended.  Additionally, I didn't see any requests where a header named `authorization` was being returned, so the `Access-Control-Expose-Headers` appeared to be not relevant to PASS.

I tested these changes locally and on stage, and logging into pass worked fine.