### PR TITLE
Remove community action

### DIFF
--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -33,32 +33,32 @@ runs:
     # Need X-server for Linux runner but not for Windows or macOS runners:
     # https://github.com/DevExpress/testcafe-action/blob/master/index.js#L64
     - name: Run acceptance tests
-      if: runner.os != "Linux"
+      # if: runner.os != "Linux"
       shell: bash
       run: |
         cd pass-acceptance-testing
         yarn install --frozen-lockfile
         npx testcafe \
-          'chrome --ignore-certificate-errors --allow-insecure-localhost' \
+          'chrome:headless --ignore-certificate-errors --allow-insecure-localhost' \
           --hostname localhost \
           tests/*Tests.js \
           --selector-timeout ${{ inputs.timeouts}} \
           --assertion-timeout ${{ inputs.timeouts}} \
           --ajax-request-timeout ${{ inputs.timeouts}}
 
-    - name: Run acceptance tests (Linux)
-      if: runner.os == "Linux"
-      shell: bash
-      run: |
-        cd pass-acceptance-testing
-        yarn install --frozen-lockfile
-        xvfb-run --server-args="-screen 0 1280x720x24" > /dev/null npx testcafe \
-          'chrome --ignore-certificate-errors --allow-insecure-localhost' \
-          --hostname localhost \
-          tests/*Tests.js \
-          --selector-timeout ${{ inputs.timeouts}} \
-          --assertion-timeout ${{ inputs.timeouts}} \
-          --ajax-request-timeout ${{ inputs.timeouts}}
+    # - name: Run acceptance tests (Linux)
+    #   if: runner.os == "Linux"
+    #   shell: bash
+    #   run: |
+    #     cd pass-acceptance-testing
+    #     yarn install --frozen-lockfile
+    #     xvfb-run --server-args="-screen 0 1280x720x24" > /dev/null npx testcafe \
+    #       'chrome:headless --ignore-certificate-errors --allow-insecure-localhost' \
+    #       --hostname localhost \
+    #       tests/*Tests.js \
+    #       --selector-timeout ${{ inputs.timeouts}} \
+    #       --assertion-timeout ${{ inputs.timeouts}} \
+    #       --ajax-request-timeout ${{ inputs.timeouts}}
 
     - name: Stop pass-docker
       shell: bash

--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -30,12 +30,18 @@ runs:
         repository: eclipse-pass/pass-acceptance-testing
         path: pass-acceptance-testing
 
+    # Can run `yarn test`, but calling testcafe directly allows us to more easily set test timeouts
     - name: Run acceptance tests
-      uses: DevExpress/testcafe-action@latest
-      with:
-        version: "3.3.0"
-        args: "'chrome --ignore-certificate-errors --allow-insecure-localhost' --hostname localhost ./pass-acceptance-testing/tests/*Tests.js --selector-timeout ${{ inputs.timeouts}} --assertion-timeout ${{ inputs.timeouts}} --ajax-request-timeout ${{ inputs.timeouts}}"
+      run: |
+        cd pass-acceptance-testing
+        yarn install --frozen-lockfile
+        npx testcafe 'chrome --ignore-certificate-errors --allow-insecure-localhost' \
+          --hostname localhost \
+          tests/*Tests.js \
+          --selector-timeout ${{ inputs.timeouts}} \
+          --assertion-timeout ${{ inputs.timeouts}} \
+          --ajax-request-timeout ${{ inputs.timeouts}}
 
     - name: Stop pass-docker
       shell: bash
-      run: docker compose down -v
+      run: cd .. && docker compose down -v

--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -16,6 +16,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - run: |
+        echo "Set timeouts: ${{ inputs.timeouts }}"
+      shell: bash
+
     - name: Append hosts file to enable "pass.local" on localhost
       shell: bash
       run: echo "127.0.0.1    pass.local" | sudo tee -a /etc/hosts
@@ -30,10 +34,7 @@ runs:
         repository: eclipse-pass/pass-acceptance-testing
         path: pass-acceptance-testing
 
-    # Need X-server for Linux runner but not for Windows or macOS runners:
-    # https://github.com/DevExpress/testcafe-action/blob/master/index.js#L64
     - name: Run acceptance tests
-      # if: runner.os != "Linux"
       shell: bash
       run: |
         cd pass-acceptance-testing
@@ -46,20 +47,7 @@ runs:
           --assertion-timeout ${{ inputs.timeouts}} \
           --ajax-request-timeout ${{ inputs.timeouts}}
 
-    # - name: Run acceptance tests (Linux)
-    #   if: runner.os == "Linux"
-    #   shell: bash
-    #   run: |
-    #     cd pass-acceptance-testing
-    #     yarn install --frozen-lockfile
-    #     xvfb-run --server-args="-screen 0 1280x720x24" > /dev/null npx testcafe \
-    #       'chrome:headless --ignore-certificate-errors --allow-insecure-localhost' \
-    #       --hostname localhost \
-    #       tests/*Tests.js \
-    #       --selector-timeout ${{ inputs.timeouts}} \
-    #       --assertion-timeout ${{ inputs.timeouts}} \
-    #       --ajax-request-timeout ${{ inputs.timeouts}}
-
     - name: Stop pass-docker
+      if: always()
       shell: bash
-      run: cd .. && docker compose down -v
+      run: cd .. && docker compose -f docker-compose.yml -f eclipse-pass.local.yml down -v

--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -32,6 +32,7 @@ runs:
 
     # Can run `yarn test`, but calling testcafe directly allows us to more easily set test timeouts
     - name: Run acceptance tests
+      shell: bash
       run: |
         cd pass-acceptance-testing
         yarn install --frozen-lockfile

--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -30,13 +30,30 @@ runs:
         repository: eclipse-pass/pass-acceptance-testing
         path: pass-acceptance-testing
 
-    # Can run `yarn test`, but calling testcafe directly allows us to more easily set test timeouts
+    # Need X-server for Linux runner but not for Windows or macOS runners:
+    # https://github.com/DevExpress/testcafe-action/blob/master/index.js#L64
     - name: Run acceptance tests
+      if: runner.os != "Linux"
       shell: bash
       run: |
         cd pass-acceptance-testing
         yarn install --frozen-lockfile
-        npx testcafe 'chrome --ignore-certificate-errors --allow-insecure-localhost' \
+        npx testcafe \
+          'chrome --ignore-certificate-errors --allow-insecure-localhost' \
+          --hostname localhost \
+          tests/*Tests.js \
+          --selector-timeout ${{ inputs.timeouts}} \
+          --assertion-timeout ${{ inputs.timeouts}} \
+          --ajax-request-timeout ${{ inputs.timeouts}}
+
+    - name: Run acceptance tests (Linux)
+      if: runner.os == "Linux"
+      shell: bash
+      run: |
+        cd pass-acceptance-testing
+        yarn install --frozen-lockfile
+        xvfb-run --server-args="-screen 0 1280x720x24" > /dev/null npx testcafe \
+          'chrome --ignore-certificate-errors --allow-insecure-localhost' \
           --hostname localhost \
           tests/*Tests.js \
           --selector-timeout ${{ inputs.timeouts}} \

--- a/.github/actions/acceptance-test/action.yml
+++ b/.github/actions/acceptance-test/action.yml
@@ -36,8 +36,8 @@ runs:
 
     - name: Run acceptance tests
       shell: bash
+      working-directory: pass-acceptance-testing
       run: |
-        cd pass-acceptance-testing
         yarn install --frozen-lockfile
         npx testcafe \
           'chrome:headless --ignore-certificate-errors --allow-insecure-localhost' \
@@ -50,4 +50,4 @@ runs:
     - name: Stop pass-docker
       if: always()
       shell: bash
-      run: cd .. && docker compose -f docker-compose.yml -f eclipse-pass.local.yml down -v
+      run: docker compose -f docker-compose.yml -f eclipse-pass.local.yml down -v


### PR DESCRIPTION
Resolves https://github.com/eclipse-pass/main/issues/848

* Remove the `DevExpress/testcafe` GH action which is deprecated
* Explicitly uses Testcafe version specified by `pass-acceptance-testing/package.json`