### PR TITLE
Change image value to be parameterized

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,8 @@
 PASS_VERSION=1.5.0-SNAPSHOT
 
+IMAGE_URI=ghcr.io/eclipse-pass/
+IMAGE_VERSION=:${PASS_VERSION}
+
 ###################################################
 # PASS_CORE config ################################
 ###################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ version: '3.8'
 #  - eclipse-pass.nightly.yml
 services:
   auth:
-    image: "ghcr.io/eclipse-pass/pass-auth:${PASS_VERSION}"
+    image: "${IMAGE_URI}pass-auth${IMAGE_VERSION}"
     container_name: auth
     env_file:
       - .env
@@ -31,7 +31,7 @@ services:
       - back
 
   pass-core:
-    image: "ghcr.io/eclipse-pass/pass-core-main:${PASS_VERSION}"
+    image: "${IMAGE_URI}pass-core-main${IMAGE_VERSION}"
     container_name: pass-core
     env_file:
       - .env
@@ -39,7 +39,7 @@ services:
       - back
 
   pass-ui:
-    image: "ghcr.io/eclipse-pass/pass-ui:${PASS_VERSION}"
+    image: "${IMAGE_URI}pass-ui${IMAGE_VERSION}"
     build:
       context: ./ember
       args:
@@ -64,7 +64,7 @@ services:
 
   proxy:
     build: ./demo-proxy/
-    image: "ghcr.io/eclipse-pass/proxy:${PASS_VERSION}"
+    image: "${IMAGE_URI}proxy${IMAGE_VERSION}"
     container_name: proxy
     env_file:
       - .env


### PR DESCRIPTION
So pass-docker can load pass app images from AWS ECR when deployed in stage/production.  

These changes are for https://github.com/eclipse-pass/main/issues/908