### PR TITLE
Update demo data for deployment test support in pass-acceptance

### DIFF
--- a/demo_data.json
+++ b/demo_data.json
@@ -429,8 +429,8 @@
       "id": "5",
       "type": "funder",
       "attributes": {
-        "localKey": "johnshopkins.edu:funder:316235",
-        "name": "SCANDINAVIAN BIOPHARMA"
+        "localKey": "johnshopkins.edu:funder:E2E_TEST_FUNDER_LK",
+        "name": "PASS_E2E_TEST_FUNDER"
       },
       "relationships": {
         "policy": {
@@ -968,6 +968,21 @@
   },
   {
     "op": "add",
+    "path": "/journal",
+    "value": {
+      "id": "10",
+      "type": "journal",
+      "attributes": {
+        "issns": [
+          "Print:test-fake"
+        ],
+        "journalName": "PASS_E2E_TEST_JOURNAL",
+        "nlmta": "PASS_E2E_TEST_JOURNAL"
+      }
+    }
+  },
+  {
+    "op": "add",
     "path": "/publication",
     "value": {
       "id": "0",
@@ -1069,11 +1084,11 @@
       "id": "1",
       "type": "grant",
       "attributes": {
-        "endDate": "2018-08-31T00:00:00.000Z",
-        "awardNumber": "Z0650001",
+        "endDate": "2088-08-31T00:00:00.000Z",
+        "awardNumber": "TEST_E2E_AWD_NUM",
         "awardDate": "2015-09-23T00:00:00.000Z",
         "awardStatus": "active",
-        "projectName": "Reversible activation of critical period plasticity in visual cortex",
+        "projectName": "TEST_E2E_GRANT",
         "startDate": "2015-09-01T00:00:00.000Z",
         "localKey": "johnshopkins.edu:grant:12345"
       },


### PR DESCRIPTION
This PR changes some of the demo data to support this PR: https://github.com/eclipse-pass/pass-acceptance-testing/pull/17

Note this PR is branched off of 903-auth which is the pass auth consolidation ticket so this PR should be merged after the 903-auth PRs are merged.

Note this commit is the only change that will be in the PR once the `903-auth` changes are merged: https://github.com/eclipse-pass/pass-docker/pull/369/commits/661e965c045141a041a7ef7c28a4d467dcc7b8a1