### PR TITLE
Fix demo acs url and idp https access

### DIFF
--- a/.eclipse-pass.JHUAWSdemo_env
+++ b/.eclipse-pass.JHUAWSdemo_env
@@ -4,6 +4,7 @@
 
 PASS_CORE_BASE_URL=https://demo.eclipse-pass.org
 PASS_CORE_IDP_METADATA=http://idp:8080/idp/shibboleth
+PASS_CORE_SP_ACS=https://demo.eclipse-pass.org/login/saml2/sso/pass
 
 ###################################################
 # IDP config #############################

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Environment variables:
 * `IDP_HOST=http://localhost:9080`
 * `SP_LOGIN=http://localhost:8080/login/saml2/sso/pass`
 
+Separately there is a non-container environment variable `IDP_INTERNAL_PORT` which is used to set the internal port on the IDP container which 9080 maps to.
+The default is 8080. This can be used to make 9080 support https by setting it to 4443 in the docker compose environment. One way to do this is by adding
+`IDP_INTERNAL_PORT=4443` to the docker compose command. Note that `-e` should not be used because it is for container environment variables.
+
 ### [`pass-core`](https://github.com/eclipse-pass/pass-core)
 
 Repository: https://github.com/eclipse-pass/pass-core

--- a/eclipse-pass.local.yml
+++ b/eclipse-pass.local.yml
@@ -52,9 +52,7 @@ services:
       - JETTY_BROWSER_SSL_KEYSTORE_PASSWORD=password
       - JETTY_BACKCHANNEL_SSL_KEYSTORE_PASSWORD=password
     ports:
-      - 9080:8080
-    expose:
-      - "4443"
+      - 9080:${IDP_INTERNAL_PORT-8080}
     env_file:
       - .env
       - .eclipse-pass.local_env


### PR DESCRIPTION
This pr sets the ACS url to use HTTPS to match how the IDP is configured.

It also adds a non-container variable IDP_INTERNAL_PORT which can be used to set the demo environment idp to have 9080 map to 4443.