### PR TITLE
Update gh workflows for complete release workflow

### DIFF
--- a/.github/workflows/pass-acceptance-tests.yml
+++ b/.github/workflows/pass-acceptance-tests.yml
@@ -5,11 +5,6 @@ on:
   pull_request:
     branches:
       - 'main'
-  push:
-    branches:
-      - 'main'
-    tags-ignore:
-      - '*'
   schedule:
     - cron: "0 2 * * *"
 

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   update-images:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -5,25 +5,17 @@ name: update-docker-images
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - 'main'
-    tags-ignore:
-      - '*'
+  pull_request:
+    types:
+      - closed
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # get-version:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     project-version: ${{ steps.project-version.outputs.version }}
-  #   steps:
-  #     - id: project-version
-  #       run: echo "VERSION=grep -Po '(?<=PASS_VERSION=).* .env" >> $GITHUB_OUTPUT
   update-images:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
Needed for complete workflow fixes PR: https://github.com/eclipse-pass/main/pull/983

Removed push trigger all together for the pass-acceptance-tests workflow. Did not add trigger for PR merge because it running tests after a PR is merged is not needed. Tests run when appropriate PRs are opened.

Changed update docker images workflow to trigger on PR merge.