### PR TITLE
Handle change of CentOS mirror location for ldap container

### DIFF
--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER John Gasper <jgasper@unicon.net>
 
 ARG TENANT
 
+# Hack to handle change in CentOS mirror
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y epel-release \
     && yum update -y \
     && yum install -y 389-ds-base 389-adminutil \


### PR DESCRIPTION
Fix taken from: https://stackoverflow.com/questions/78692851/could-not-retrieve-mirrorlist-http-mirrorlist-centos-org-release-7arch-x86-6