### PR TITLE
Add data/config for InvenioRDM

### DIFF
--- a/.eclipse-pass.local_env
+++ b/.eclipse-pass.local_env
@@ -48,6 +48,10 @@ DSPACE_SERVER=dspace:8080
 DSPACE_USER=test@test.edu
 DSPACE_PASSWORD=admin
 
+INVENIORDM_API_BASE_URL=https://pass-docker-invenio-rdm-frontend-1/api
+INVENIORDM_VERIFY_SSL_CERT=false
+INVENIORDM_API_TOKEN=<generated_api_key>
+
 PMC_FTP_HOST=pmc-sftp-server
 PMC_FTP_PORT=22
 PMC_FTP_USER=pmcsftpuser

--- a/demo_data.json
+++ b/demo_data.json
@@ -70,6 +70,26 @@
   },
   {
     "op": "add",
+    "path": "/repository",
+    "value": {
+      "id": "4",
+      "type": "repository",
+      "attributes": {
+        "agreementText": "InvenioRDM agreement",
+        "integrationType": "full",
+        "formSchema": "{\"id\":\"InvenioRDM\",\"schema\":{\"title\":\"InvenioRDM <br><p class=\"lead text-muted\">Deposit requirements.</p>\",\"type\":\"object\",\"properties\":{\"authors\":{\"title\":\"<div class=\"row\"><div class=\"col-6\">Author(s) <small class=\"text-muted\">(required)</small></div><div class=\"col-6 p-0\"></div></div>\",\"type\":\"array\",\"uniqueItems\":true,\"items\":{\"type\":\"object\",\"properties\":{\"author\":{\"type\":\"string\",\"fieldClass\":\"body-text col-6 pull-left pl-0\"}}}}}},\"options\":{\"fields\":{\"authors\":{\"hidden\":false}}}}",
+        "name": "InvenioRDM",
+        "url": "https://inveniosoftware.org/products/rdm/",
+        "repositoryKey": "inveniordm",
+        "schemas": [
+          "https://eclipse-pass.github.io/metadata-schemas/jhu/jscholarship.json",
+          "https://eclipse-pass.github.io/metadata-schemas/jhu/common.json"
+        ]
+      }
+    }
+  },
+  {
+    "op": "add",
     "path": "/policy",
     "value": {
       "id": "0",
@@ -346,6 +366,29 @@
   },
   {
     "op": "add",
+    "path": "/policy",
+    "value": {
+      "id": "12",
+      "type": "policy",
+      "attributes": {
+        "policyUrl": "https://inveniosoftware.org/products/rdm/",
+        "description": "InvenioRDM policy description",
+        "title": "InvenioRDM Policy"
+      },
+      "relationships": {
+        "repositories": {
+          "data": [
+            {
+              "id": "4",
+              "type": "repository"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
     "path": "/funder",
     "value": {
       "id": "0",
@@ -436,6 +479,26 @@
         "policy": {
           "data": {
             "id": "0",
+            "type": "policy"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/funder",
+    "value": {
+      "id": "6",
+      "type": "funder",
+      "attributes": {
+        "localKey": "johnshopkins.edu:funder:INVENIORDM_FUNDER_LK",
+        "name": "INVENIORDM_TEST_FUNDER"
+      },
+      "relationships": {
+        "policy": {
+          "data": {
+            "id": "12",
             "type": "policy"
           }
         }
@@ -1497,6 +1560,43 @@
         "primaryFunder": {
           "data": {
             "id": "4",
+            "type": "funder"
+          }
+        }
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/grant",
+    "value": {
+      "id": "11",
+      "type": "grant",
+      "attributes": {
+        "endDate": "2026-07-31T00:00:00.000Z",
+        "startDate": "2023-07-01T00:00:00.000Z",
+        "awardDate": "2023-08-04T00:00:00.000Z",
+        "awardNumber": "invenio-test-awd-num-1",
+        "awardStatus": "active",
+        "projectName": "PASS TEST INVENIORDM GRANT",
+        "localKey": "johnshopkins.edu:grant:112233"
+      },
+      "relationships": {
+        "pi": {
+          "data": {
+            "id": "2",
+            "type": "user"
+          }
+        },
+        "directFunder": {
+          "data": {
+            "id": "6",
+            "type": "funder"
+          }
+        },
+        "primaryFunder": {
+          "data": {
+            "id": "6",
             "type": "funder"
           }
         }

--- a/deposit/deposit-repositories.json
+++ b/deposit/deposit-repositories.json
@@ -69,5 +69,16 @@
         "default-directory": "/upload/%s"
       }
     }
+  },
+  "InvenioRDM": {
+    "assembler": {
+      "specification": "invenioRdm",
+      "beanName": "invenioRdmAssembler"
+    },
+    "transport-config": {
+      "protocol-binding": {
+        "protocol": "invenioRdm"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR contains changes to the demo_data and configuration to be able to test the PASS and InvenioRDM integration.

Here are the steps to get things up and running and do the submisson/deposit:

**Run mvn clean install in the pass-support/pass-deposit-services module.**

**Start InvenioRDM and generate access token:**

- cd to the pass-docker/invenio-rdm directory and run ./start.sh, wait for the server to fully start
- open a browser and go to https://172.0.0.1/ and login using the admin user in pass-docker/invenio-rdm/pass-docker-invenio-rdm/app_data/users.yaml
- click on the user menu button on the top right and click Applications
- click New token in the Personal access tokens
- enter a Name and click Create
- copy the Access token
- paste the token value in the pass-docker/.eclipse-pass.local_env as the value for the `INVENIORDM_API_TOKEN` property

**Start pass-docker:**

- in the pass-docker dir, run `docker compose -p pass-docker -f docker-compose.yml -f eclipse-pass.local.yml -f docker-compose-deposit.yml -f docker-compose-deposit-invenio-rdm.yml up -d --no-build --quiet-pull`

**Submit submission:**

- open a browser and go to http://localhost:8080/app/
- login using the staff1 user
- Create a new submission
- on the grant selection, select the `PASS TEST INVENIORDM GRANT` grant
- on the Details, enter a Publisher name, Publication Date (yyyy-mm-dd), Author in format <last_name>, <first_name>

After the submission is processed, a link will show up for the deposit on the submission details page.  You can click the link to the view the deposit in invenioRdm.

~~Note: There is this bug I ran across that I need to address: https://github.com/eclipse-pass/pass-support/pull/122#issuecomment-2256813464.  I will update this PR once I have put a fix in to handle this issue.~~
I have added a retry for this call so it is good now.