### PR TITLE
Update pass-core user env names

### DIFF
--- a/.eclipse-pass.local_env
+++ b/.eclipse-pass.local_env
@@ -11,8 +11,8 @@ AWS_SQS_ENDPOINT_OVERRIDE=http://localstack:4566
 # PASS_CORE config ################################
 ###################################################
 PASS_CORE_BASE_URL=http://localhost:8080
-PASS_CORE_BACKEND_USER=backend
-PASS_CORE_BACKEND_PASSWORD=backend
+PASS_CORE_USER=backend
+PASS_CORE_PASSWORD=backend
 
 PASS_CORE_POSTGRES_PORT=5432
 PASS_CORE_DATABASE_URL=jdbc:postgresql://postgres:5432/pass

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Environment variables:
 
 * `PASS_CORE_BASE_URL=http://localhost:8080` : Used when generating JSON API relationship links. Needs to be absolute and must change to match deployment environment
 * `PASS_CORE_POSTGRES_PORT=5432`
-* `PASS_CORE_BACKEND_USER=backend`
-* `PASS_CORE_BACKEND_PASSWORD=backend`
+* `PASS_CORE__USER=backend`
+* `PASS_CORE_PASSWORD=backend`
 * `PASS_CORE_APP_LOCATION=http://pass-ui:81/app/` : Resource location of pass ui resources
 * `PASS_CORE_APP_CSP=default-src 'self';` : Content Security Policy header value
 * `PASS_CORE_IDP_METADATA=http://idp:8080/idp/shibboleth` : Resource location of IDP metadata

--- a/eclipse-pass.local.yml
+++ b/eclipse-pass.local.yml
@@ -14,7 +14,7 @@ services:
       - .env
       - .eclipse-pass.local_env
     healthcheck:
-      test: 'curl -u "$$PASS_CORE_BACKEND_USER:$$PASS_CORE_BACKEND_PASSWORD" -f http://pass-core:8080/data/user || exit 1'
+      test: 'curl -u "$$PASS_CORE_USER:$$PASS_CORE_PASSWORD" -f http://pass-core:8080/data/user || exit 1'
       start_period: 60s
       interval: 5s
     ports:
@@ -103,7 +103,7 @@ services:
       - .env
       - .eclipse-pass.local_env
     entrypoint: /bin/sh -c
-    command: [ 'curl http://pass-core:8080/data/ -u "$$PASS_CORE_BACKEND_USER:$$PASS_CORE_BACKEND_PASSWORD" -X PATCH -H "content-type: application/vnd.api+json;ext=jsonpatch" -H "accept:application/vnd.api+json; ext=jsonpatch" -H "X-XSRF-TOKEN:moo" -H "Cookie:XSRF-TOKEN=moo" -d "@/data.json"' ]
+    command: [ 'curl http://pass-core:8080/data/ -u "$$PASS_CORE_USER:$$PASS_CORE_PASSWORD" -X PATCH -H "content-type: application/vnd.api+json;ext=jsonpatch" -H "accept:application/vnd.api+json; ext=jsonpatch" -H "X-XSRF-TOKEN:moo" -H "Cookie:XSRF-TOKEN=moo" -d "@/data.json"' ]
     networks:
       - back
     depends_on:


### PR DESCRIPTION
This PR is changing the pass-core user env var names to align with the changes made the pass-core optional AWS parameter store PR https://github.com/eclipse-pass/pass-core/pull/93.

The pass-core will need to be merge before tests pass for this PR.  To test locally, pull the dev branch for the pass-core PR, run `mvn clean install`.  Then you should be able to start pass-docker local with the config in this PR.