### PR TITLE
Fix local testing DSpace deposit failure

### DIFF
--- a/dspace-cli.yml
+++ b/dspace-cli.yml
@@ -11,7 +11,7 @@ version: "3.7"
 
 services:
   dspace-cli:
-    image: "${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-dspace-7_x}"
+    image: "${DOCKER_OWNER:-dspace}/dspace-cli:dspace-7.6"
     container_name: dspace-cli
     environment:
       # Below syntax may look odd, but it is how to override dspace.cfg settings via env variables.


### PR DESCRIPTION
Needed to use `dspace-7.6` tag for DSpace cli image commands.