### PR TITLE
Remove md5 algorithm option from deposit-services config

### DIFF
--- a/deposit/deposit-repositories.json
+++ b/deposit/deposit-repositories.json
@@ -7,8 +7,7 @@
         "archive": "ZIP",
         "compression": "NONE",
         "algorithms": [
-          "sha512",
-          "md5"
+          "sha512"
         ],
         "funder-mapping": {}
       }


### PR DESCRIPTION
Related to https://github.com/eclipse-pass/pass-support/pull/160