### PR TITLE
Handle Alpaca replacement

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,8 @@ PASS_CORE_POLICY_INSTITUTIONAL_REPOSITORY_NAME=JScholarship
 
 PASS_CORE_APP_LOCATION=http://pass-ui:81/app/
 
-PASS_CORE_APP_CSP="default-src 'none'; script-src 'self' 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; script-src-elem 'self' https://code.jquery.com/jquery-3.6.4.min.js https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.8/handlebars.js https://code.cloudcms.com/alpaca/1.5.24/bootstrap/alpaca.min.js; img-src 'self'; style-src 'self' https://fonts.googleapis.com/css2; frame-ancestors 'none'; form-action 'self';"
+# style-src-attr unsafe-inline needed by SurveyJS
+PASS_CORE_APP_CSP="default-src 'none'; script-src 'self' 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; script-src-elem 'self'; img-src 'self'; style-src 'self' https://fonts.googleapis.com/css2; frame-ancestors 'none'; form-action 'self'; style-src-attr 'unsafe-inline';"
 
 ###################################################
 # PASS_UI config ##################################

--- a/.env
+++ b/.env
@@ -19,7 +19,7 @@ PASS_CORE_POLICY_INSTITUTIONAL_REPOSITORY_NAME=JScholarship
 PASS_CORE_APP_LOCATION=http://pass-ui:81/app/
 
 # style-src-attr unsafe-inline needed by SurveyJS
-PASS_CORE_APP_CSP="default-src 'none'; script-src 'self' 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; script-src-elem 'self'; img-src 'self'; style-src 'self' https://fonts.googleapis.com/css2; frame-ancestors 'none'; form-action 'self'; style-src-attr 'unsafe-inline';"
+PASS_CORE_APP_CSP="default-src 'none'; script-src 'self' 'unsafe-eval'; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; script-src-elem 'self'; img-src 'self'; style-src 'self' 'unsafe-hashes' 'sha256-uajJzYzlBbv8Rt0kmXSqBvuT+/lyGUPnck2FFR/SqOY=' https://fonts.googleapis.com/css2; frame-ancestors 'none'; form-action 'self';"
 
 ###################################################
 # PASS_UI config ##################################

--- a/demo_data.json
+++ b/demo_data.json
@@ -446,7 +446,14 @@
         "localKey": "johnshopkins.edu:funder:301694",
         "name": "WILLIAM AND ELLA OWENS MEDICAL RESE"
       },
-      "relationships": {}
+        "relationships": {
+          "policy": {
+            "data": {
+              "id": "2",
+              "type": "policy"
+            }
+          }
+        }
     }
   },
   {

--- a/demo_data.json
+++ b/demo_data.json
@@ -7,10 +7,12 @@
       "type": "repository",
       "attributes": {
         "integrationType": "web-link",
-        "formSchema": "{\"id\":\"eric\",\"schema\":{\"title\":\"Department of Education - ERIC <br><small>Requires deposit to Education Resource Information Center (ERIC).</small><br><br><p class=\"lead text-muted\">Automatic submission from PASS to ERIC is not available at this time. Instead, submission to ERIC will be prompted before this submission is finalized in PASS. The publication information collected so far can be used to complete the submission via the ERIC website.</p>\",\"type\":\"object\",\"properties\":{}},\"options\":{\"fields\":{}}}",
         "name": "Educational Resources Information Center (ERIC)",
         "url": "https://eric.ed.gov/",
-        "repositoryKey": "eric"
+        "repositoryKey": "eric",
+        "schemas": [
+          "https://eclipse-pass.github.io/metadata-schemas/jhu/common.json"
+        ]
       }
     }
   },

--- a/docker-compose-dspace.yml
+++ b/docker-compose-dspace.yml
@@ -125,6 +125,7 @@ services:
         DSPACE_REST_HOST: localhost
         DSPACE_REST_PORT: 9000
         DSPACE_REST_NAMESPACE: /server
+        DSPACE_MARKDOWN_ENABLED: true
       image: dspace/dspace-angular:dspace-7.6
       networks:
         back:


### PR DESCRIPTION
Update the CSP to remove no longer used libraries and allow SurveyJS to work.
The DSpace UI config is changed to enable support for HTML abstracts. This is useful for testing.
A demo grant `Metaplasticity in a Transgenic Mouse Model of Alzheimer Disease` is updated to point to a web-link repo to help with manual testing.

See https://github.com/surveyjs/survey-library/issues/8714 for info on why unsafe-inline is required. A hash could be used instead.